### PR TITLE
fix(ci): bump Go to 1.26.4 — clear govulncheck stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/provabl/attest
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Problem

The weekly **Security Scan** workflow has been failing on every scheduled run (Mondays). `govulncheck` flags **8 Go standard-library advisories** that the pinned toolchain (`go 1.25.9`) is behind on:

| Advisory | Package |
|---|---|
| GO-2026-5039 | net/textproto |
| GO-2026-5037 | crypto/x509 |
| GO-2026-4986 | net/mail |
| GO-2026-4982 | html/template |
| GO-2026-4980 | html/template |
| GO-2026-4977 | net/mail |
| GO-2026-4971 | net (DialURL / LookupHost) |
| GO-2026-4918 | net/http |

None are attest code bugs — all are in the standard library, fixed in **go1.25.11 / go1.26.4**.

## Fix

Bump the `go` directive in `go.mod` from `1.25.9` → `1.26.4`. All workflows resolve their toolchain via `go-version-file: go.mod`, so this single change fixes CI everywhere.

## Verification (local, go1.26.4)

```
govulncheck ./...  ->  No vulnerabilities found. (0)
go build ./...     ->  ok
go test ./...      ->  ok
```