### PR TITLE
feat(evaluator): Cedar context entity for workload attributes (closes #103)

### DIFF
--- a/cmd/attest/main.go
+++ b/cmd/attest/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/provabl/attest/internal/integrations/grc"
 	"github.com/provabl/attest/internal/multisre"
 	"github.com/provabl/attest/internal/principal"
+	"github.com/provabl/attest/internal/workload"
 	"github.com/provabl/attest/internal/provision"
 	"github.com/provabl/attest/internal/artifact"
 	"github.com/provabl/attest/internal/attestation"
@@ -1499,6 +1500,21 @@ Provide principal, action, resource ARNs and entity attributes as --attr flags.`
 				}
 			}
 
+			// Workload attributes from vet (context.workload.*), read from
+			// vet's gate-result.json if present. Absent → no context keys, and
+			// policies requiring context.workload.* default to deny.
+			workloadDir, _ := cmd.Flags().GetString("workload-dir")
+			if wl, err := workload.Load(workloadDir); err != nil {
+				return fmt.Errorf("loading workload attributes: %w", err)
+			} else if wl != nil {
+				attributes["context.workload.slsa_level"] = int64(wl.SLSALevel)
+				attributes["context.workload.sbom_present"] = wl.SBOMPresent
+				attributes["context.workload.cve_critical"] = wl.CVECritical
+				attributes["context.workload.cve_high"] = wl.CVEHigh
+				attributes["context.workload.signed"] = wl.Signed
+				attributes["context.workload.artifact_hash"] = wl.ArtifactHash
+			}
+
 			// Build Cedar request.
 			req := evaluator.AuthzRequest{
 				PrincipalARN: principalARN,
@@ -1550,6 +1566,7 @@ Provide principal, action, resource ARNs and entity attributes as --attr flags.`
 	cmd.Flags().String("ldap-url", "", "LDAP server URL for principal attribute resolution (optional)")
 	cmd.Flags().String("ldap-base-dn", "", "LDAP base DN (required with --ldap-url)")
 	cmd.Flags().String("region", "us-east-1", "AWS region for SAML/IAM attribute resolution")
+	cmd.Flags().String("workload-dir", ".vet", "directory containing vet's gate-result.json for context.workload.* attributes")
 	_ = cmd.MarkFlagRequired("principal")
 	_ = cmd.MarkFlagRequired("action")
 	_ = cmd.MarkFlagRequired("resource")

--- a/docs/integrations/vet.md
+++ b/docs/integrations/vet.md
@@ -1,0 +1,75 @@
+# vet ↔ attest Integration Contract
+
+**vet** (github.com/provabl/vet) is the software supply-chain verification tool in the
+Provabl suite. After `vet gate`, it writes `.vet/gate-result.json` with the appraised
+supply-chain posture of an artifact. attest reads that file and makes the result
+available to Cedar policies as `context.workload.*` attributes.
+
+This document is the formal contract between the two systems. Both sides must adhere to
+it. The coupling point is the **JSON shape** of `gate-result.json` — not a shared Go
+type — so vet and attest version independently.
+
+---
+
+## The Interface: gate-result.json → Cedar context
+
+vet writes a JSON file. attest reads it. attest does **not** run vet's evidence kernel;
+appraisal happens in vet at the source, and the durable artifact is the lowered JSON.
+
+**Direction**: vet gate → `.vet/gate-result.json` → attest `internal/workload` reader →
+Cedar `context.workload.*`
+
+attest reads the file via `internal/workload.Load(dir)` (default dir `.vet`). When the
+file is absent, the workload context is simply unset — policies that require
+`context.workload.*` then default to deny under the forbid-unless pattern, exactly as a
+missing principal attribute does.
+
+---
+
+## Attribute Schema
+
+`gate-result.json` fields map to `context.workload.*` Cedar attributes. Keys are
+**snake_case**, consistent with attest's principal attributes (`principal.cui_training_current`).
+
+| JSON field | Type | Cedar attribute | Notes |
+|---|---|---|---|
+| `slsa_level` | int | `context.workload.slsa_level` | SLSA provenance level; `0` = not verified |
+| `sbom_present` | bool | `context.workload.sbom_present` | SBOM attached and attested |
+| `cve_critical` | bool | `context.workload.cve_critical` | critical CVEs present |
+| `cve_high` | bool | `context.workload.cve_high` | high CVEs present |
+| `signed` | bool | `context.workload.signed` | cosign/Sigstore signature verified |
+| `artifact_hash` | string | `context.workload.artifact_hash` | subject digest |
+
+The `artifact`, `policy_met`, and `evaluated_at` fields of `gate-result.json` are not
+surfaced as Cedar attributes.
+
+**Single mapping point:** the JSON-field → attribute mapping lives only in
+`internal/workload/workload.go` (`Load`) and `pkg/schema.WorkloadAttributes`'s json tags.
+A vet field rename is a one-line fix there.
+
+### Example policy
+
+```cedar
+permit(principal, action, resource in ResourceGroup::"cui-data")
+when {
+  principal.cui_training_current == true &&   // from qualify (IAM tags)
+  context.workload.slsa_level >= 2 &&         // from vet (gate-result.json)
+  context.workload.cve_critical == false
+};
+```
+
+---
+
+## Why attest does not re-appraise (relates to #102)
+
+Each tool in the suite runs the evidence kernel **in-process** with an **ephemeral**
+attestation-manager key and persists only the *lowered* result (qualify → `attest:*` IAM
+tags; vet → `gate-result.json`). The evidence bundle is never persisted and the signing
+key never leaves the process, so there is no cross-process bundle for attest to verify.
+
+attest is the **policy decision point**. It consumes the lowered attributes that are the
+product of appraisal at the source. Re-appraising them in attest would re-judge
+already-judged data under a fresh key — ceremony with no new trust property. This is the
+"appraisal produces the verdict; Cedar acts on it; they never merge" boundary from
+ADR 0001. Consequently attest's resolver/evaluator consume attributes; they do not run
+the kernel.

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -102,6 +102,7 @@ func (e *Evaluator) EvaluateWithPolicies(ctx context.Context, ps *cedar.PolicySe
 		Principal: principalUID,
 		Action:    actionUID,
 		Resource:  resourceUID,
+		Context:   buildContext(req.Attributes),
 	}
 
 	decision, diag := cedar.Authorize(ps, entities, cedarReq)
@@ -292,6 +293,38 @@ func buildAttributes(attrs map[string]any, prefix string) types.Record {
 		}
 		attrName := parts[1]
 		rm[types.String(attrName)] = toValue(v)
+	}
+	return types.NewRecord(rm)
+}
+
+// buildContext builds the Cedar request Context from the flat attribute map.
+// Unlike buildAttributes (which produces a FLAT record for principal/resource),
+// the Cedar Context is a record of records: a key like "context.workload.slsa_level"
+// becomes Context = {workload: {slsa_level: ...}}, so policies read
+// context.workload.slsa_level. The grouping is generic over the middle segment,
+// so additional groups (e.g. context.platform.* from a future runtime-attestation
+// source) need no change here.
+//
+// Returns an empty (non-nil) record when there are no context.* attributes, which
+// is required: Cedar's Request.Context must always be a valid Record.
+func buildContext(attrs map[string]any) types.Record {
+	groups := map[string]types.RecordMap{}
+	for k, v := range attrs {
+		// Expect exactly context.<group>.<attr>.
+		parts := strings.SplitN(k, ".", 3)
+		if len(parts) != 3 || parts[0] != "context" {
+			continue
+		}
+		group, attrName := parts[1], parts[2]
+		if groups[group] == nil {
+			groups[group] = types.RecordMap{}
+		}
+		groups[group][types.String(attrName)] = toValue(v)
+	}
+
+	rm := types.RecordMap{}
+	for group, m := range groups {
+		rm[types.String(group)] = types.NewRecord(m)
 	}
 	return types.NewRecord(rm)
 }

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/cedar-policy/cedar-go/types"
 )
 
 func newPermitAllPolicySet(t *testing.T) *cedar.PolicySet {
@@ -174,5 +175,77 @@ func TestEvaluateWithPolicies_WithAttributes(t *testing.T) {
 				t.Errorf("attrs %v: expected %s, got %s", tc.attrs, tc.wantEffect, d.Effect)
 			}
 		})
+	}
+}
+
+// TestEvaluateWithPolicies_WorkloadContext proves the Cedar Context entity is
+// populated from context.workload.* attributes (vet's gate-result.json, lowered
+// by the CLI), so policies can gate on supply-chain posture. End-to-end proof of #103.
+func TestEvaluateWithPolicies_WorkloadContext(t *testing.T) {
+	ev := NewEvaluator(nil)
+
+	slsaPolicy, err := cedar.NewPolicySetFromBytes("slsa.cedar",
+		[]byte(`permit(principal, action, resource) when { context.workload.slsa_level >= 2 };`))
+	if err != nil {
+		t.Fatalf("parse slsa policy: %v", err)
+	}
+	signedPolicy, err := cedar.NewPolicySetFromBytes("signed.cedar",
+		[]byte(`permit(principal, action, resource) when { context.workload.signed == true };`))
+	if err != nil {
+		t.Fatalf("parse signed policy: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		ps         *cedar.PolicySet
+		attrs      map[string]any
+		wantEffect string
+	}{
+		{"slsa 2 meets >=2", slsaPolicy, map[string]any{"context.workload.slsa_level": int64(2)}, "ALLOW"},
+		{"slsa 1 below >=2", slsaPolicy, map[string]any{"context.workload.slsa_level": int64(1)}, "DENY"},
+		{"slsa absent context", slsaPolicy, map[string]any{}, "DENY"},
+		{"signed true", signedPolicy, map[string]any{"context.workload.signed": true}, "ALLOW"},
+		{"signed absent", signedPolicy, map[string]any{}, "DENY"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &AuthzRequest{
+				PrincipalARN: "arn:aws:iam::123456789012:role/Workload",
+				Action:       "s3:GetObject",
+				ResourceARN:  "arn:aws:s3:::cui-data/obj",
+				Attributes:   tc.attrs,
+			}
+			d, err := ev.EvaluateWithPolicies(context.Background(), tc.ps, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.Effect != tc.wantEffect {
+				t.Errorf("attrs %v: expected %s, got %s", tc.attrs, tc.wantEffect, d.Effect)
+			}
+		})
+	}
+}
+
+// TestBuildContext_Nesting verifies context.<group>.<attr> keys produce a nested
+// record-of-records (the shape policies read as context.workload.slsa_level).
+func TestBuildContext_Nesting(t *testing.T) {
+	ctx := buildContext(map[string]any{
+		"context.workload.slsa_level": int64(2),
+		"context.workload.signed":     true,
+		"principal.ignored":           "x", // non-context keys are skipped
+	})
+	wl, ok := ctx.Get(types.String("workload"))
+	if !ok {
+		t.Fatal("expected nested 'workload' record in context")
+	}
+	wlRec, ok := wl.(types.Record)
+	if !ok {
+		t.Fatalf("workload is %T, want types.Record", wl)
+	}
+	if v, _ := wlRec.Get(types.String("slsa_level")); v != types.Long(2) {
+		t.Errorf("workload.slsa_level = %v, want 2", v)
+	}
+	if v, _ := wlRec.Get(types.String("signed")); v != types.Boolean(true) {
+		t.Errorf("workload.signed = %v, want true", v)
 	}
 }

--- a/internal/principal/resolver.go
+++ b/internal/principal/resolver.go
@@ -16,6 +16,15 @@
 //
 // The plugin interface is open source. Connectors for specific institutional
 // systems are community-maintained.
+//
+// On consuming evidence (provabl/evidence, ADR 0001): attest is the policy
+// decision point. The attest:* IAM tags this resolver reads are the *lowered*
+// product of appraisal that already happened in qualify (and vet, for
+// context.workload.*, via gate-result.json — see docs/integrations/vet.md).
+// Because the producing tools appraise in-process with ephemeral keys and persist
+// only lowered attributes, there is no cross-process evidence bundle for attest to
+// re-verify. attest therefore consumes appraised attributes rather than re-running
+// the kernel — "appraisal produces the verdict; Cedar acts on it; they never merge."
 package principal
 
 import (

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+// Package workload reads vet's gate-result.json into schema.WorkloadAttributes
+// for Cedar context.workload.* evaluation.
+//
+// attest is the policy decision point: it consumes the lowered supply-chain
+// attributes vet produces. It does NOT run vet's evidence kernel — appraisal
+// happens in vet at the source, and the durable artifact is the JSON file this
+// package reads. Coupling to vet's JSON shape (not its Go types) is deliberate:
+// it lets vet and attest version independently. The single point that maps
+// gate-result.json field names to attest's struct is Load, below — keep it the
+// only place, so a vet field rename is a one-line fix here.
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/provabl/attest/pkg/schema"
+)
+
+// DefaultVetDir is the conventional .vet directory vet writes into.
+const DefaultVetDir = ".vet"
+
+// gateResultFile is the file vet's `gate` command writes within the .vet dir.
+const gateResultFile = "gate-result.json"
+
+// Load reads gate-result.json from dir (dir/gate-result.json). If dir is empty it
+// defaults to ".vet". It returns (nil, nil) when the file is absent: workload
+// context is then simply unset, and policies that require context.workload.*
+// default to deny under the forbid-unless pattern — exactly as a missing
+// principal attribute does. An error is returned only when the file exists but
+// cannot be read or parsed.
+func Load(dir string) (*schema.WorkloadAttributes, error) {
+	if dir == "" {
+		dir = DefaultVetDir
+	}
+	path := filepath.Join(dir, gateResultFile)
+
+	data, err := os.ReadFile(path) // #nosec G304 — operator-controlled path
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// The SINGLE mapping from vet's gate-result.json to attest's workload schema.
+	// schema.WorkloadAttributes' json tags match vet's GateResult field tags, so
+	// extra fields (artifact, policy_met, evaluated_at) are ignored on decode.
+	var attrs schema.WorkloadAttributes
+	if err := json.Unmarshal(data, &attrs); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &attrs, nil
+}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/provabl/attest/pkg/schema"
 )
@@ -38,9 +39,24 @@ func Load(dir string) (*schema.WorkloadAttributes, error) {
 	if dir == "" {
 		dir = DefaultVetDir
 	}
-	path := filepath.Join(dir, gateResultFile)
 
-	data, err := os.ReadFile(path) // #nosec G304 — operator-controlled path
+	// Confine the read to dir: the filename is a fixed constant, so the joined
+	// path must resolve to a direct child of dir. This rejects a dir like
+	// "../../etc" escaping anywhere unexpected before we touch the filesystem.
+	base, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving workload dir %q: %w", dir, err)
+	}
+	path := filepath.Join(base, gateResultFile)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving workload path: %w", err)
+	}
+	if !strings.HasPrefix(abs+string(filepath.Separator), base+string(filepath.Separator)) {
+		return nil, fmt.Errorf("workload path %q escapes %q", abs, base)
+	}
+
+	data, err := os.ReadFile(abs) // #nosec G304 — confined to base above
 	if os.IsNotExist(err) {
 		return nil, nil
 	}

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+package workload_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/provabl/attest/internal/workload"
+)
+
+func writeGateResult(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "gate-result.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func TestLoad_PresentFile(t *testing.T) {
+	dir := t.TempDir()
+	// Mirrors vet's gate-result.json — note the extra fields attest ignores.
+	writeGateResult(t, dir, `{
+		"artifact": "ghcr.io/test/app:v1.0",
+		"artifact_hash": "sha256:abc123",
+		"slsa_level": 2,
+		"sbom_present": true,
+		"cve_critical": false,
+		"cve_high": true,
+		"signed": true,
+		"policy_met": true,
+		"evaluated_at": "2026-06-08T00:00:00Z"
+	}`)
+
+	attrs, err := workload.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if attrs == nil {
+		t.Fatal("expected attributes, got nil")
+	}
+	if attrs.SLSALevel != 2 {
+		t.Errorf("SLSALevel = %d, want 2", attrs.SLSALevel)
+	}
+	if !attrs.SBOMPresent || !attrs.Signed || !attrs.CVEHigh {
+		t.Errorf("bool fields wrong: %+v", attrs)
+	}
+	if attrs.CVECritical {
+		t.Error("CVECritical should be false")
+	}
+	if attrs.ArtifactHash != "sha256:abc123" {
+		t.Errorf("ArtifactHash = %q, want sha256:abc123", attrs.ArtifactHash)
+	}
+}
+
+func TestLoad_AbsentFile(t *testing.T) {
+	// Empty temp dir — no gate-result.json. Absent is not an error.
+	attrs, err := workload.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	if attrs != nil {
+		t.Errorf("expected nil for absent file, got %+v", attrs)
+	}
+}
+
+func TestLoad_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeGateResult(t, dir, `{not valid json`)
+
+	if _, err := workload.Load(dir); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -445,6 +445,27 @@ type PrincipalAttributes struct {
 	Attributes        map[string]string `json:"attributes,omitempty"`          // extensible attributes
 }
 
+// --- Workload Attributes ---
+
+// WorkloadAttributes are the software supply-chain attributes Cedar policies
+// evaluate as context.workload.* (e.g. context.workload.slsa_level >= 2).
+//
+// They are produced by vet (github.com/provabl/vet), which writes
+// .vet/gate-result.json after a `vet gate`. attest reads that JSON artifact (see
+// internal/workload) — it does not run vet's evidence kernel. Appraisal happens
+// in vet at the source; attest is the PDP that consumes the lowered result.
+// Only the six attributes the integration contract names are surfaced here; the
+// artifact, policy_met, and evaluated_at fields of gate-result.json are ignored.
+// See docs/integrations/vet.md for the contract.
+type WorkloadAttributes struct {
+	SLSALevel    int    `json:"slsa_level"`    // Cedar: context.workload.slsa_level (0 = not verified)
+	SBOMPresent  bool   `json:"sbom_present"`  // Cedar: context.workload.sbom_present
+	CVECritical  bool   `json:"cve_critical"`  // Cedar: context.workload.cve_critical
+	CVEHigh      bool   `json:"cve_high"`      // Cedar: context.workload.cve_high
+	Signed       bool   `json:"signed"`        // Cedar: context.workload.signed
+	ArtifactHash string `json:"artifact_hash"` // Cedar: context.workload.artifact_hash
+}
+
 // --- Cedar Evaluation ---
 
 // CedarDecision records a single Cedar PDP authorization decision.


### PR DESCRIPTION
Closes #103. Relates to #102, #104. Phase-two **Stream A consumer side** of [ADR 0001](https://github.com/provabl/provabl/blob/main/docs/adr/0001-evidence-kernel-beneath-cedar.md) — epic hub provabl/evidence#2 — after the merged producer re-points vet#9 and qualify#39.

## What changes
attest's evaluator built `types.Request{Principal, Action, Resource}` with **no Context**, so Cedar policies could not reference `context.*` even though cedar-go v1.6.0 supports it. This wires the Context entity and reads vet's supply-chain posture into it — so policies can gate on `context.workload.*` alongside `principal.*` training.

## Files
- **`pkg/schema/types.go`** — `WorkloadAttributes` (slsa_level, sbom_present, cve_critical, cve_high, signed, artifact_hash); Go fields PascalCase, json tags snake_case matching vet's `gate-result.json`.
- **`internal/workload/workload.go`** (new) — `Load(dir)` reads `.vet/gate-result.json`; absent → `(nil,nil)` (policies default-deny, like a missing principal attr); malformed → error. The **single** point mapping vet's JSON → attest's schema. **No evidence-kernel dependency** — attest reads the JSON artifact, it does not run the kernel.
- **`internal/evaluator/evaluator.go`** — new `buildContext` builds a **nested** record-of-records from `context.<group>.<attr>` keys (reusing `toValue`) and sets `cedarReq.Context`. Generic over the middle segment, so a future `context.platform.*` (nitro, #104) needs **zero** evaluator change. Returns an empty (valid) Record when no `context.*` keys.
- **`cmd/attest/main.go`** — `attest evaluate` gains `--workload-dir` (default `.vet`); injects `context.workload.*` (`int64` slsa_level → Cedar `Long`).

## Casing decision
Cedar keys are **snake_case** (`context.workload.slsa_level`) — consistent with every existing `principal.*` attribute and a zero-munge copy of vet's JSON tags. **Note:** the umbrella CLAUDE.md names these PascalCase; a companion umbrella PR corrects that doc + adds the ADR ephemeral-key paragraph.

## #102 — satisfied by design (no code)
Producing tools (qualify, vet) appraise **in-process with ephemeral keys** and persist only **lowered** attributes (IAM tags / gate-result.json). There is no cross-process evidence bundle for attest to re-verify, and re-appraising already-appraised data under a fresh key adds ceremony with no new trust property. attest is the PDP; it consumes the lowered product. Documented in new **`docs/integrations/vet.md`** + the `principal` package doc. #102 closes as satisfied-by-design.

## Verification
- `go build/vet/test ./...` green.
- New evaluator test: `context.workload.slsa_level >= 2` policy → **ALLOW@2 / DENY@1 / DENY-absent**; plus a `signed == true` case and a `buildContext` nesting unit test.
- Reader test: present / absent / malformed.
- **End-to-end**: `attest evaluate` against a real `.vet/gate-result.json` → ALLOW at slsa_level 2, DENY at 1, DENY when `.vet` absent.