### PR TITLE
feat(evaluator): inject nitro runtime attestation into context.platform.* (closes #104)

### DIFF
--- a/cmd/attest/main.go
+++ b/cmd/attest/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/provabl/attest/internal/integrations/grc"
 	"github.com/provabl/attest/internal/multisre"
 	"github.com/provabl/attest/internal/principal"
+	"github.com/provabl/attest/internal/platform"
 	"github.com/provabl/attest/internal/workload"
 	"github.com/provabl/attest/internal/provision"
 	"github.com/provabl/attest/internal/artifact"
@@ -1515,6 +1516,23 @@ Provide principal, action, resource ARNs and entity attributes as --attr flags.`
 				attributes["context.workload.artifact_hash"] = wl.ArtifactHash
 			}
 
+			// Platform attributes from the nitro provider (context.platform.*),
+			// read from .nitro/attestation.json if present. Absent → no context
+			// keys, and policies requiring context.platform.* default to deny.
+			platformDir, _ := cmd.Flags().GetString("platform-dir")
+			if pl, err := platform.Load(platformDir); err != nil {
+				return fmt.Errorf("loading platform attributes: %w", err)
+			} else if pl != nil {
+				attributes["context.platform.nitro_attested"] = pl.NitroAttested
+				attributes["context.platform.module_id"] = pl.ModuleID
+				attributes["context.platform.nonce_verified"] = pl.NonceVerified
+				attributes["context.platform.signature_valid"] = pl.SignatureValid
+				attributes["context.platform.pcr0"] = pl.PCR0
+				attributes["context.platform.pcr1"] = pl.PCR1
+				attributes["context.platform.pcr2"] = pl.PCR2
+				attributes["context.platform.pcr8"] = pl.PCR8
+			}
+
 			// Build Cedar request.
 			req := evaluator.AuthzRequest{
 				PrincipalARN: principalARN,
@@ -1567,6 +1585,7 @@ Provide principal, action, resource ARNs and entity attributes as --attr flags.`
 	cmd.Flags().String("ldap-base-dn", "", "LDAP base DN (required with --ldap-url)")
 	cmd.Flags().String("region", "us-east-1", "AWS region for SAML/IAM attribute resolution")
 	cmd.Flags().String("workload-dir", ".vet", "directory containing vet's gate-result.json for context.workload.* attributes")
+	cmd.Flags().String("platform-dir", ".nitro", "directory containing nitro's attestation.json for context.platform.* attributes")
 	_ = cmd.MarkFlagRequired("principal")
 	_ = cmd.MarkFlagRequired("action")
 	_ = cmd.MarkFlagRequired("resource")

--- a/docs/integrations/nitro.md
+++ b/docs/integrations/nitro.md
@@ -1,0 +1,99 @@
+# nitro ↔ attest Integration Contract
+
+**nitro** is the runtime/enclave attestation provider in the evidence kernel
+(`github.com/provabl/evidence`, `providers/nitro`). It verifies an AWS Nitro Enclave
+attestation document — native nonce binding, PCR policy, COSE_Sign1 signature to the AWS
+Nitro PKI root — and lowers the verdict to `platform.*` attributes. A nitro tool / enclave
+runtime writes the lowered result to `.nitro/attestation.json`; attest reads that file and
+makes it available to Cedar policies as `context.platform.*` attributes.
+
+This document is the formal contract between the two. The coupling point is the **JSON
+shape** of `attestation.json` — not a shared Go type — so the producer and attest version
+independently.
+
+> **Status:** attest ships the *consumer* half (the reader + the `context.platform.*`
+> wiring). The producer that writes `.nitro/attestation.json` — a nitro CLI or the enclave
+> runtime running the evidence kernel's nitro provider and lowering its verdict — does not
+> exist yet (tracked in provabl/evidence#5). Until then the file is simply absent, and
+> policies requiring `context.platform.*` default to deny. attest is correct today; the
+> end-to-end loop closes when the producer lands.
+
+---
+
+## The Interface: attestation.json → Cedar context
+
+A nitro tool writes a JSON file. attest reads it. attest does **not** run the evidence
+kernel; appraisal happens at the source (the enclave), and the durable artifact is the
+lowered JSON.
+
+**Direction**: nitro provider → `.nitro/attestation.json` → attest `internal/platform`
+reader → Cedar `context.platform.*`
+
+attest reads the file via `internal/platform.Load(dir)` (default dir `.nitro`). When the
+file is absent, the platform context is simply unset — policies that require
+`context.platform.*` then default to deny under the forbid-unless pattern, exactly as a
+missing principal attribute does.
+
+---
+
+## Attribute Schema
+
+`attestation.json` fields map to `context.platform.*` Cedar attributes. Keys are
+**snake_case**, consistent with `context.workload.*` and `principal.*`.
+
+| JSON field | Type | Cedar attribute | Notes |
+|---|---|---|---|
+| `nitro_attested` | bool | `context.platform.nitro_attested` | overall verdict (nonce bound, signature valid, PCRs matched) |
+| `module_id` | string | `context.platform.module_id` | enclave module id |
+| `nonce_verified` | bool | `context.platform.nonce_verified` | the document carried the issued challenge (native binding) |
+| `signature_valid` | bool | `context.platform.signature_valid` | COSE_Sign1 chains to the AWS Nitro PKI root |
+| `pcr0` | string | `context.platform.pcr0` | enclave image (SHA384 hex) |
+| `pcr1` | string | `context.platform.pcr1` | kernel / bootstrap |
+| `pcr2` | string | `context.platform.pcr2` | application |
+| `pcr8` | string | `context.platform.pcr8` | signing certificate |
+
+**Single mapping point:** the JSON-field → attribute mapping lives only in
+`internal/platform/platform.go` (`Load`) and `pkg/schema.PlatformAttributes`'s json tags.
+A producer field rename is a one-line fix there.
+
+### Example policy
+
+```cedar
+permit(principal, action, resource in ResourceGroup::"cui-data")
+when {
+  principal.cui_training_current == true &&     // from qualify (IAM tags)
+  context.workload.slsa_level >= 2 &&           // from vet (gate-result.json)
+  context.platform.nitro_attested == true &&    // from nitro (attestation.json)
+  context.platform.pcr0 == "<expected-enclave-image>"
+};
+```
+
+This is the full picture the evidence kernel enables: the *person* is trained (qualify),
+the *software* is provenance-verified (vet), and the *runtime* is a known-good enclave
+(nitro) — all appraised at the source and consumed here as Cedar attributes.
+
+---
+
+## Why attest does not re-appraise (relates to #102)
+
+Each producer in the suite runs the evidence kernel **in-process** with an **ephemeral**
+attestation-manager key and persists only the *lowered* result (qualify → `attest:*` IAM
+tags; vet → `gate-result.json`; nitro → `attestation.json`). The evidence bundle is never
+persisted and the signing key never leaves the process, so there is no cross-process bundle
+for attest to verify.
+
+attest is the **policy decision point**. It consumes the lowered attributes that are the
+product of appraisal at the source. Re-appraising them would re-judge already-judged data
+under a fresh key — ceremony with no new trust property. This is the "appraisal produces
+the verdict; Cedar acts on it; they never merge" boundary from ADR 0001.
+
+---
+
+## ground's IAM-layer counterpart
+
+attest evaluates `context.platform.*` in Cedar (application-layer). ground deploys an
+SCP (`policies/nitro_attestation_scp.json`, provabl/ground#12) that denies sensitive-data
+actions unless the principal carries `aws:PrincipalTag/attest:nitro-attested == "true"` —
+the IAM-layer counterpart. The same attestation result drives both: Cedar context here, a
+principal tag there. (Who writes that principal tag is the same open producer step noted
+above.)

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -226,6 +226,56 @@ func TestEvaluateWithPolicies_WorkloadContext(t *testing.T) {
 	}
 }
 
+// TestEvaluateWithPolicies_PlatformContext proves the Cedar Context entity is
+// populated from context.platform.* attributes (nitro's attestation.json, lowered
+// by the CLI), so policies can gate on runtime/enclave attestation. End-to-end
+// proof of #104. No evaluator change was needed: buildContext groups
+// context.<group>.* generically, so context.platform.* works like context.workload.*.
+func TestEvaluateWithPolicies_PlatformContext(t *testing.T) {
+	ev := NewEvaluator(nil)
+
+	attestedPolicy, err := cedar.NewPolicySetFromBytes("attested.cedar",
+		[]byte(`permit(principal, action, resource) when { context.platform.nitro_attested == true };`))
+	if err != nil {
+		t.Fatalf("parse attested policy: %v", err)
+	}
+	pcrPolicy, err := cedar.NewPolicySetFromBytes("pcr.cedar",
+		[]byte(`permit(principal, action, resource) when { context.platform.pcr0 == "expected-image" };`))
+	if err != nil {
+		t.Fatalf("parse pcr policy: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		ps         *cedar.PolicySet
+		attrs      map[string]any
+		wantEffect string
+	}{
+		{"attested true", attestedPolicy, map[string]any{"context.platform.nitro_attested": true}, "ALLOW"},
+		{"attested false", attestedPolicy, map[string]any{"context.platform.nitro_attested": false}, "DENY"},
+		{"attested absent", attestedPolicy, map[string]any{}, "DENY"},
+		{"pcr0 matches", pcrPolicy, map[string]any{"context.platform.pcr0": "expected-image"}, "ALLOW"},
+		{"pcr0 differs", pcrPolicy, map[string]any{"context.platform.pcr0": "rogue-image"}, "DENY"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &AuthzRequest{
+				PrincipalARN: "arn:aws:iam::123456789012:role/Workload",
+				Action:       "s3:GetObject",
+				ResourceARN:  "arn:aws:s3:::cui-data/obj",
+				Attributes:   tc.attrs,
+			}
+			d, err := ev.EvaluateWithPolicies(context.Background(), tc.ps, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.Effect != tc.wantEffect {
+				t.Errorf("attrs %v: expected %s, got %s", tc.attrs, tc.wantEffect, d.Effect)
+			}
+		})
+	}
+}
+
 // TestBuildContext_Nesting verifies context.<group>.<attr> keys produce a nested
 // record-of-records (the shape policies read as context.workload.slsa_level).
 func TestBuildContext_Nesting(t *testing.T) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+// Package platform reads a nitro attestation result into schema.PlatformAttributes
+// for Cedar context.platform.* evaluation.
+//
+// attest is the policy decision point: it consumes the lowered runtime-attestation
+// attributes the evidence kernel's nitro provider produces. It does NOT run the
+// evidence kernel — appraisal happens at the source (an enclave / a nitro tool),
+// and the durable artifact is the JSON file this package reads. Coupling to the
+// JSON shape (not a shared Go type) lets the producer and attest version
+// independently. The single point that maps the JSON field names to attest's
+// struct is Load, below — keep it the only place so a field rename is a one-line
+// fix here.
+package platform
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/provabl/attest/pkg/schema"
+)
+
+// DefaultNitroDir is the conventional .nitro directory the attestation result is
+// written into.
+const DefaultNitroDir = ".nitro"
+
+// attestationFile is the file the nitro tool / enclave runtime writes within the
+// .nitro dir.
+const attestationFile = "attestation.json"
+
+// Load reads attestation.json from dir (dir/attestation.json). If dir is empty it
+// defaults to ".nitro". It returns (nil, nil) when the file is absent: platform
+// context is then simply unset, and policies that require context.platform.*
+// default to deny under the forbid-unless pattern — exactly as a missing
+// principal attribute does. An error is returned only when the file exists but
+// cannot be read or parsed.
+func Load(dir string) (*schema.PlatformAttributes, error) {
+	if dir == "" {
+		dir = DefaultNitroDir
+	}
+
+	// Confine the read to dir: the filename is a fixed constant, so the joined
+	// path must resolve to a direct child of dir. This rejects a dir like
+	// "../../etc" escaping anywhere unexpected before we touch the filesystem.
+	base, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving nitro dir %q: %w", dir, err)
+	}
+	path := filepath.Join(base, attestationFile)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving nitro path: %w", err)
+	}
+	if !strings.HasPrefix(abs+string(filepath.Separator), base+string(filepath.Separator)) {
+		return nil, fmt.Errorf("nitro path %q escapes %q", abs, base)
+	}
+
+	data, err := os.ReadFile(abs) // #nosec G304 — confined to base above
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// The SINGLE mapping from the nitro attestation JSON to attest's platform
+	// schema. schema.PlatformAttributes' json tags match the nitro provider's
+	// lowered platform.* claim keys.
+	var attrs schema.PlatformAttributes
+	if err := json.Unmarshal(data, &attrs); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &attrs, nil
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+package platform_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/provabl/attest/internal/platform"
+)
+
+func writeAttestation(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "attestation.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func TestLoad_PresentFile(t *testing.T) {
+	dir := t.TempDir()
+	writeAttestation(t, dir, `{
+		"nitro_attested": true,
+		"module_id": "i-0abc.enclave",
+		"nonce_verified": true,
+		"signature_valid": true,
+		"pcr0": "aa",
+		"pcr1": "bb",
+		"pcr2": "cc",
+		"pcr8": "dd"
+	}`)
+
+	attrs, err := platform.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if attrs == nil {
+		t.Fatal("expected attributes, got nil")
+	}
+	if !attrs.NitroAttested || !attrs.NonceVerified || !attrs.SignatureValid {
+		t.Errorf("bool fields wrong: %+v", attrs)
+	}
+	if attrs.ModuleID != "i-0abc.enclave" {
+		t.Errorf("ModuleID = %q", attrs.ModuleID)
+	}
+	if attrs.PCR0 != "aa" || attrs.PCR8 != "dd" {
+		t.Errorf("PCR fields wrong: %+v", attrs)
+	}
+}
+
+func TestLoad_AbsentFile(t *testing.T) {
+	attrs, err := platform.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	if attrs != nil {
+		t.Errorf("expected nil for absent file, got %+v", attrs)
+	}
+}
+
+func TestLoad_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeAttestation(t, dir, `{not valid json`)
+	if _, err := platform.Load(dir); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -466,6 +466,29 @@ type WorkloadAttributes struct {
 	ArtifactHash string `json:"artifact_hash"` // Cedar: context.workload.artifact_hash
 }
 
+// --- Platform Attributes ---
+
+// PlatformAttributes are the runtime/enclave attestation attributes Cedar
+// policies evaluate as context.platform.* (e.g. context.platform.nitro_attested
+// == true).
+//
+// They are produced by the evidence kernel's nitro provider (AWS Nitro enclave
+// attestation: native nonce binding, PCR policy, signature verification). A nitro
+// tool / enclave runtime writes .nitro/attestation.json with the lowered result;
+// attest reads that JSON artifact (see internal/platform) — it does not run the
+// evidence kernel. Appraisal happens at the source; attest is the PDP that
+// consumes the lowered result. See docs/integrations/nitro.md for the contract.
+type PlatformAttributes struct {
+	NitroAttested  bool   `json:"nitro_attested"`  // Cedar: context.platform.nitro_attested (overall verdict)
+	ModuleID       string `json:"module_id"`       // Cedar: context.platform.module_id
+	NonceVerified  bool   `json:"nonce_verified"`  // Cedar: context.platform.nonce_verified
+	SignatureValid bool   `json:"signature_valid"` // Cedar: context.platform.signature_valid
+	PCR0           string `json:"pcr0"`            // Cedar: context.platform.pcr0 (enclave image)
+	PCR1           string `json:"pcr1"`            // Cedar: context.platform.pcr1 (kernel/bootstrap)
+	PCR2           string `json:"pcr2"`            // Cedar: context.platform.pcr2 (application)
+	PCR8           string `json:"pcr8"`            // Cedar: context.platform.pcr8 (signing certificate)
+}
+
 // --- Cedar Evaluation ---
 
 // CedarDecision records a single Cedar PDP authorization decision.


### PR DESCRIPTION
Closes #104. Relates to #1, provabl/ground#12. Phase-two **Stream B (consumer side)** of [ADR 0001](https://github.com/provabl/provabl/blob/main/docs/adr/0001-evidence-kernel-beneath-cedar.md) — epic hub provabl/evidence#2 — following the nitro provider in **evidence v0.2.0** and mirroring the merged #103 (`context.workload.*`).

## What this is
Surfaces nitro's runtime/enclave attestation to Cedar as **`context.platform.*`**, so policies can gate on **enclave identity** alongside `principal.*` (training, qualify) and `context.workload.*` (supply chain, vet). Completes the three-layer picture.

## Files
- **`pkg/schema/types.go`** — `PlatformAttributes` (nitro_attested, module_id, nonce_verified, signature_valid, pcr0/1/2/8); snake_case json tags matching the nitro provider's lowered claims.
- **`internal/platform/platform.go`** (new) — `Load(dir)` reads `.nitro/attestation.json` (mirrors `internal/workload`, incl. the `filepath.Abs` confinement the custom Semgrep rule requires); absent → `(nil,nil)` (default-deny); malformed → error. Single mapping point.
- **`cmd/attest/main.go`** — `attest evaluate` gains `--platform-dir` (default `.nitro`); injects `context.platform.*`.
- **NO evaluator change** — `buildContext` (from #103) groups `context.<group>.<attr>` generically, so `context.platform.*` works exactly like `context.workload.*`. (This is the payoff of #103's generic design.)
- **`docs/integrations/nitro.md`** — the contract + the attested/workload/training example policy + the ground#12 IAM-layer counterpart.

## Boundary
**No evidence-kernel dependency** — attest reads the durable JSON artifact, it does not run the kernel (the #102/#103 boundary). The producer that writes `.nitro/attestation.json` (a nitro CLI / enclave runtime) doesn't exist yet (provabl/evidence#5); attest ships the **consumer half** now, absent file → default-deny, so it's correct today and the loop closes when the producer lands.

## Example policy (full three-layer gate)
```cedar
permit(principal, action, resource in ResourceGroup::"cui-data")
when {
  principal.cui_training_current == true &&     // qualify
  context.workload.slsa_level >= 2 &&           // vet
  context.platform.nitro_attested == true       // nitro
};
```

## Verification
`go build/vet/test ./...` green · new evaluator test: `context.platform.nitro_attested == true` → ALLOW/DENY/DENY-absent + a pcr0-match case · reader test present/absent/malformed · **e2e** `attest evaluate` against a real `.nitro/attestation.json` → ALLOW attested / DENY unattested / DENY absent · Semgrep 0 findings.