### PR TITLE
chore: copyright holder → Playground Logic LLC

### DIFF
--- a/.github/workflows/regulatory-watch.yml
+++ b/.github/workflows/regulatory-watch.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 name: Regulatory Watch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Playground Logic
+   Copyright 2026 Playground Logic LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,5 +3,5 @@ version = 1
 [[annotations]]
 path = ["**.json", "**.yaml", "**.yml", "**.sql", "**.md", "**.toml", "**.cedar", "**.cast"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 Scott Friedman"
+SPDX-FileCopyrightText = "2026 Playground Logic LLC"
 SPDX-License-Identifier = "Apache-2.0"

--- a/cmd/attest/main.go
+++ b/cmd/attest/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/frameworks/cmmc-level-1/framework.yaml
+++ b/frameworks/cmmc-level-1/framework.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 id: cmmc-level-1

--- a/frameworks/nih-gds/framework.yaml
+++ b/frameworks/nih-gds/framework.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # NIH Genomic Data Sharing Policy — Researcher Tier

--- a/frameworks/nist-800-223/framework.yaml
+++ b/frameworks/nist-800-223/framework.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # NIST SP 800-223 — High-Performance Computing (HPC) Security

--- a/internal/ai/analyst.go
+++ b/internal/ai/analyst.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package ai implements AI-powered compliance capabilities using

--- a/internal/artifact/client.go
+++ b/internal/artifact/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package artifact provides a client for the AWS Artifact API.

--- a/internal/artifact/client_test.go
+++ b/internal/artifact/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package artifact

--- a/internal/attestation/cosign.go
+++ b/internal/attestation/cosign.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package attestation manages human-affirmed compliance attestation records.

--- a/internal/attestation/manager.go
+++ b/internal/attestation/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package attestation manages human-affirmed compliance attestation records.

--- a/internal/attestation/manager_test.go
+++ b/internal/attestation/manager_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package attestation

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package auth implements OIDC-based authentication and Cedar authorization

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package auth

--- a/internal/compiler/cedar/compiler.go
+++ b/internal/compiler/cedar/compiler.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cedar compiles framework controls into Cedar policies for

--- a/internal/compiler/cedar/compiler_test.go
+++ b/internal/compiler/cedar/compiler_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cedar

--- a/internal/compiler/scp/compiler.go
+++ b/internal/compiler/scp/compiler.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package scp compiles framework control definitions into AWS Service Control Policies.

--- a/internal/compiler/scp/compiler_test.go
+++ b/internal/compiler/scp/compiler_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package scp

--- a/internal/dashboard/cedar_authz.go
+++ b/internal/dashboard/cedar_authz.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package dashboard

--- a/internal/dashboard/cedar_authz_test.go
+++ b/internal/dashboard/cedar_authz_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package dashboard

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package dashboard implements the web dashboard for attest.

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package dashboard

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package deploy handles deploying compiled policy artifacts to an AWS Organization.

--- a/internal/deploy/deployer_cfn.go
+++ b/internal/deploy/deployer_cfn.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package deploy provides CloudFormation stack deployment alongside the

--- a/internal/deploy/deployer_test.go
+++ b/internal/deploy/deployer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package deploy

--- a/internal/document/assessment/generator.go
+++ b/internal/document/assessment/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package assessment generates CMMC 2.0 Level 2 self-assessment scores

--- a/internal/document/assessment/generator_test.go
+++ b/internal/document/assessment/generator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package assessment

--- a/internal/document/cmmc/bundle.go
+++ b/internal/document/cmmc/bundle.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cmmc generates CMMC Level 2 assessment documentation bundles.

--- a/internal/document/cmmc/bundle_test.go
+++ b/internal/document/cmmc/bundle_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmmc

--- a/internal/document/dmsp/generator.go
+++ b/internal/document/dmsp/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package dmsp generates NIH Data Management and Security Plans (DMSP).

--- a/internal/document/oscal/exporter.go
+++ b/internal/document/oscal/exporter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package oscal exports compliance documents in NIST OSCAL format.

--- a/internal/document/oscal/oscal_test.go
+++ b/internal/document/oscal/oscal_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package oscal

--- a/internal/document/poam/generator.go
+++ b/internal/document/poam/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package poam generates Plan of Action & Milestones from the crosswalk.

--- a/internal/document/poam/generator_test.go
+++ b/internal/document/poam/generator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package poam

--- a/internal/document/ssp/generator.go
+++ b/internal/document/ssp/generator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package ssp generates System Security Plans from the SRE state.

--- a/internal/document/ssp/multi_ssp.go
+++ b/internal/document/ssp/multi_ssp.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package ssp

--- a/internal/document/ssp/renderer.go
+++ b/internal/document/ssp/renderer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package ssp

--- a/internal/document/ssp/renderer_test.go
+++ b/internal/document/ssp/renderer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package ssp

--- a/internal/document/ssp/supersessions.go
+++ b/internal/document/ssp/supersessions.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package ssp

--- a/internal/evaluator/cloudtrail.go
+++ b/internal/evaluator/cloudtrail.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package evaluator

--- a/internal/evaluator/cloudtrail_test.go
+++ b/internal/evaluator/cloudtrail_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package evaluator

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package evaluator implements the Cedar PDP for runtime compliance evaluation.

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package evaluator

--- a/internal/evaluator/sqs.go
+++ b/internal/evaluator/sqs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package evaluator

--- a/internal/framework/conflicts.go
+++ b/internal/framework/conflicts.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package framework

--- a/internal/framework/conflicts_test.go
+++ b/internal/framework/conflicts_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package framework

--- a/internal/framework/loader.go
+++ b/internal/framework/loader.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package framework loads, validates, and manages compliance framework definitions.

--- a/internal/framework/loader_test.go
+++ b/internal/framework/loader_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package framework

--- a/internal/framework/security_test.go
+++ b/internal/framework/security_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package framework

--- a/internal/iac/generator_security_test.go
+++ b/internal/iac/generator_security_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package iac

--- a/internal/iac/output.go
+++ b/internal/iac/output.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package iac generates Infrastructure-as-Code output from compiled policy artifacts.

--- a/internal/iac/output_test.go
+++ b/internal/iac/output_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package iac

--- a/internal/iac/security_test.go
+++ b/internal/iac/security_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package iac

--- a/internal/integrations/grc/client.go
+++ b/internal/integrations/grc/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package grc provides a client for pushing OSCAL compliance documents to

--- a/internal/integrations/grc/client_test.go
+++ b/internal/integrations/grc/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package grc

--- a/internal/integrations/services.go
+++ b/internal/integrations/services.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package integrations provides clients for AWS security services that

--- a/internal/multisre/cost.go
+++ b/internal/multisre/cost.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/multisre/cost_test.go
+++ b/internal/multisre/cost_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/multisre/manager.go
+++ b/internal/multisre/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package multisre manages compliance across multiple AWS Organizations (SREs).

--- a/internal/multisre/manager_test.go
+++ b/internal/multisre/manager_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/multisre/orgid_test.go
+++ b/internal/multisre/orgid_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/multisre/security_test.go
+++ b/internal/multisre/security_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/multisre/toctou_test.go
+++ b/internal/multisre/toctou_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package multisre

--- a/internal/obligations/engine.go
+++ b/internal/obligations/engine.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package obligations provides deterministic compliance obligation mapping.

--- a/internal/obligations/engine_test.go
+++ b/internal/obligations/engine_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package obligations_test

--- a/internal/org/analyzer.go
+++ b/internal/org/analyzer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package org reads an AWS Organization and maps it to the SRE model.

--- a/internal/org/analyzer_test.go
+++ b/internal/org/analyzer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package org

--- a/internal/org/prerequisites.go
+++ b/internal/org/prerequisites.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package org

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package output provides terminal-safe print functions.

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package output

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package platform reads a nitro attestation result into schema.PlatformAttributes

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package platform_test

--- a/internal/principal/resolver.go
+++ b/internal/principal/resolver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package principal resolves entity attributes for Cedar policy evaluation.

--- a/internal/principal/resolver_test.go
+++ b/internal/principal/resolver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package principal

--- a/internal/provision/provisioner.go
+++ b/internal/provision/provisioner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package provision automates compliant environment creation.

--- a/internal/regulatory/analyzer.go
+++ b/internal/regulatory/analyzer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package regulatory

--- a/internal/regulatory/sources.go
+++ b/internal/regulatory/sources.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package regulatory provides automated monitoring of regulatory sources

--- a/internal/regulatory/store.go
+++ b/internal/regulatory/store.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package regulatory

--- a/internal/regulatory/watcher.go
+++ b/internal/regulatory/watcher.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package regulatory

--- a/internal/regulatory/watcher_test.go
+++ b/internal/regulatory/watcher_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package regulatory_test

--- a/internal/reporting/incidents.go
+++ b/internal/reporting/incidents.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package reporting contains trend analysis and incident lifecycle management.

--- a/internal/reporting/incidents_test.go
+++ b/internal/reporting/incidents_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package reporting

--- a/internal/reporting/reporting.go
+++ b/internal/reporting/reporting.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package reporting generates trend analysis from posture history.

--- a/internal/store/git.go
+++ b/internal/store/git.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package store manages the git-backed policy store in .attest/.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package store

--- a/internal/testing/runner.go
+++ b/internal/testing/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package testing provides policy testing capabilities:

--- a/internal/waiver/manager.go
+++ b/internal/waiver/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package waiver manages compliance exceptions. Real compliance has

--- a/internal/waiver/manager_test.go
+++ b/internal/waiver/manager_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package waiver

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package workload reads vet's gate-result.json into schema.WorkloadAttributes

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package workload_test

--- a/pkg/schema/tags.go
+++ b/pkg/schema/tags.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package schema

--- a/pkg/schema/types.go
+++ b/pkg/schema/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package schema defines the core data model for compliance frameworks,


### PR DESCRIPTION
Normalizes the copyright holder to **2026 Playground Logic LLC** (the legal entity) across SPDX file headers, NOTICE, REUSE.toml, and the LICENSE footer. No behavior change; build + tests unaffected.