### PR TITLE
chore: copyright prose → Playground Logic LLC; backfill CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cedar `context` entity** (`internal/evaluator`): the evaluator now builds and passes a Cedar
+  request `Context` (it previously only set principal/resource), so policies can gate on
+  `context.*`. `buildContext` groups `context.<group>.<attr>` keys into a nested record-of-records
+  generically. (#103)
+- **`context.workload.*` from vet** (#103): new `internal/workload` reader loads vet's
+  `.vet/gate-result.json` into `schema.WorkloadAttributes`; `attest evaluate --workload-dir` injects
+  `context.workload.{slsa_level,sbom_present,cve_critical,cve_high,signed,artifact_hash}`. See
+  `docs/integrations/vet.md`.
+- **`context.platform.*` from nitro** (#104): new `internal/platform` reader loads a nitro
+  attestation result (`.nitro/attestation.json`) into `schema.PlatformAttributes`; `attest evaluate
+  --platform-dir` injects `context.platform.{nitro_attested,module_id,nonce_verified,signature_valid,pcr0..8}`.
+  No evaluator change needed (the `context.<group>.*` machinery is generic). See
+  `docs/integrations/nitro.md`.
+
+### Changed
+
+- **Go 1.26.4**: bumped the `go` directive to clear the GO-2026-* standard-library advisories the
+  weekly Security Scan flagged. (#101)
+- Copyright holder normalized to Playground Logic LLC.
+
+### Notes
+
+- #102 (resolver reads "appraised" attributes) resolved as satisfied-by-design: producing tools
+  appraise in-process with ephemeral keys and persist only lowered attributes, so attest consumes
+  those lowered attributes (IAM tags / JSON artifacts) rather than re-appraising. See ADR 0001.
+
 ## [0.25.1] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -234,4 +234,4 @@ See [COMMERCIAL.md](COMMERCIAL.md) for the complete boundary and rationale.
 
 ## License
 
-Apache 2.0. Copyright 2026 Scott Friedman.
+Apache 2.0. Copyright 2026 Playground Logic LLC.

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,7 +331,7 @@ aws organizations tag-resource --resource-id 123456789012 \
             </div>
             <div class="footer-bottom">
                 <span>Made by <a href="https://github.com/scttfrdmn">@scttfrdmn</a></span>
-                <span>© 2026 Scott Friedman. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
+                <span>© 2026 Playground Logic LLC. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>.</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Sweeps README/docs prose copyright to Playground Logic LLC and backfills the empty `[Unreleased]` from merged work: context entity + `context.workload.*` (#103), `context.platform.*` (#104), Go 1.26.4 (#101), #102 satisfied-by-design note. Docs/CI only.