### PR TITLE
feat(schema): versioned attest:* tag contract + conformance test (qualify#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Versioned `attest:*` tag schema contract** (qualify#32): the `attest:*` IAM tag namespace
+  shared with qualify is now anchored by a canonical, machine-readable `pkg/schema/attest-tags-schema.json`
+  (byte-identical with qualify's copy) plus a `SchemaVersion` constant. A conformance test
+  (`pkg/schema/tags_schema_test.go`) locks attest's tag-key constants to the schema, so a rename
+  or addition on either side fails CI instead of silently breaking Cedar evaluation. No new module
+  dependency — attest still imports no `provabl/*` package. See `docs/integrations/qualify.md`.
 - **Cedar `context` entity** (`internal/evaluator`): the evaluator now builds and passes a Cedar
   request `Context` (it previously only set principal/resource), so policies can gate on
   `context.*`. `buildContext` groups `context.<group>.<attr>` keys into a nested record-of-records

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Framework contributions welcome — see [`frameworks/CONTRIBUTING.md`](framework
 | Policy testing + simulation | GRC integrations (OSCAL continuous) |
 | IaC output (Terraform, CDK) | Operational monitoring + alerting |
 | Waiver + attestation management | Managed regulatory watch |
-| qualify tag schema contract | Framework customization service |
+| [qualify tag schema contract](docs/integrations/qualify.md) (versioned) | Framework customization service |
 
 See [COMMERCIAL.md](COMMERCIAL.md) for the complete boundary and rationale.
 

--- a/docs/integrations/qualify.md
+++ b/docs/integrations/qualify.md
@@ -10,6 +10,38 @@ to it. Changes to the tag schema require coordination and a version bump.
 
 ---
 
+## Schema versioning (the drift guard)
+
+The tag keys below are the contract. Historically each side declared them
+independently (qualify `internal/training/tags.go`, attest `pkg/schema/tags.go`), so a
+rename on one side would silently break the other — qualify writes the new key, attest
+reads the old one, and Cedar evaluates the attribute as missing rather than erroring
+(qualify#32).
+
+That gap is now closed without coupling the two products at build time (attest imports
+no `provabl/*` module; neither product requires the other):
+
+- A **canonical, machine-readable schema** — `attest-tags-schema.json` — is the single
+  source of truth. It is **byte-identical** in both repos (attest
+  `pkg/schema/attest-tags-schema.json`, qualify `internal/training/attest-tags-schema.json`;
+  verify with `shasum`). attest owns the `attest:` namespace.
+- Each repo **embeds** that JSON and a **conformance test** locks its Go constants to it:
+  attest asserts its declared constants == the schema keys; qualify asserts its constants
+  == the `writer: "qualify"` keys, and that `moduleTagMap` / `ModuleExpiryTag` match the
+  schema's `module` / `expiry` metadata. A drift fails CI with an actionable message.
+- A `SchemaVersion` **constant** in each repo must equal the schema's `version` field.
+
+**To change the schema** (add / remove / rename a key): edit `attest-tags-schema.json` in
+**both** repos (keep them byte-identical), update the Go constants, bump `SchemaVersion`
+in both, and release together. The conformance tests make skipping any of these a CI
+failure rather than a silent production break.
+
+Each schema entry records `writer` (`qualify` | `attest` | `legacy`), `type`
+(`bool` | `timestamp` | `string`), and — for the qualify training tags — the source
+`module` and paired `expiry` key.
+
+---
+
 ## The Interface: IAM Role Tags
 
 qualify writes tags. attest reads them. The interface is the AWS IAM tag API — neither

--- a/pkg/schema/attest-tags-schema.json
+++ b/pkg/schema/attest-tags-schema.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Canonical schema for the attest:* IAM role tag namespace shared between qualify (writer) and attest (reader). This file is byte-identical in both repos: provabl/attest pkg/schema/attest-tags-schema.json and provabl/qualify internal/training/attest-tags-schema.json. attest owns the namespace. Each repo embeds this file and a conformance test locks its Go constants to it, so any key change fails CI until BOTH the schema and the version are updated. See https://github.com/provabl/qualify/issues/32.",
+  "version": 1,
+  "namespace": "attest:",
+  "tags": [
+    { "key": "attest:cui-training",                      "writer": "qualify", "type": "bool",      "module": "cui-fundamentals",               "expiry": "attest:cui-training-expiry" },
+    { "key": "attest:cui-training-expiry",               "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:hipaa-training",                    "writer": "qualify", "type": "bool",      "module": "hipaa-privacy-security",         "expiry": "attest:hipaa-training-expiry" },
+    { "key": "attest:hipaa-training-expiry",             "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:awareness-training",                "writer": "qualify", "type": "bool",      "module": "security-awareness",            "expiry": "attest:awareness-training-expiry" },
+    { "key": "attest:awareness-training-expiry",         "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:ferpa-training",                    "writer": "qualify", "type": "bool",      "module": "ferpa-basics",                  "expiry": "attest:ferpa-training-expiry" },
+    { "key": "attest:ferpa-training-expiry",             "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:itar-training",                     "writer": "qualify", "type": "bool",      "module": "itar-export-control",           "expiry": "attest:itar-training-expiry" },
+    { "key": "attest:itar-training-expiry",              "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:data-class-training",               "writer": "qualify", "type": "bool",      "module": "data-classification",           "expiry": "attest:data-class-training-expiry" },
+    { "key": "attest:data-class-training-expiry",        "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:research-security-training",        "writer": "qualify", "type": "bool",      "module": "nih-research-security",         "expiry": "attest:research-security-training-expiry" },
+    { "key": "attest:research-security-training-expiry", "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:coc-check-current",                 "writer": "qualify", "type": "bool",      "module": "countries-of-concern-awareness", "expiry": "attest:coc-check-expiry" },
+    { "key": "attest:coc-check-expiry",                  "writer": "qualify", "type": "timestamp" },
+    { "key": "attest:country",                           "writer": "qualify", "type": "string" },
+    { "key": "attest:lab-id",                            "writer": "qualify", "type": "string" },
+    { "key": "attest:admin-level",                       "writer": "qualify", "type": "string" },
+    { "key": "attest:nih-approval",                      "writer": "attest",  "type": "bool",      "expiry": "attest:nih-approval-expiry" },
+    { "key": "attest:nih-approval-expiry",               "writer": "attest",  "type": "timestamp" },
+    { "key": "attest:nih-dua-id",                        "writer": "attest",  "type": "string" },
+    { "key": "attest:cui-expiry",                        "writer": "legacy",  "type": "timestamp" }
+  ]
+}

--- a/pkg/schema/tags.go
+++ b/pkg/schema/tags.go
@@ -3,17 +3,65 @@
 
 package schema
 
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+// SchemaVersion is the version of the attest:* IAM tag contract shared between
+// qualify (writer) and attest (reader). It MUST equal the "version" field of the
+// canonical attest-tags-schema.json embedded below, and the same constant in
+// qualify's internal/training/tags.go. Bump it (in both repos, same release)
+// whenever a tag key is added, removed, or renamed.
+// See: https://github.com/provabl/qualify/issues/32
+const SchemaVersion = 1
+
+// canonicalTagsSchemaJSON is the byte-identical canonical schema, also present in
+// qualify at internal/training/attest-tags-schema.json. The conformance test in
+// tags_schema_test.go locks the constants in this file to it, so a drift between
+// the Go constants and the schema (or between the two repos' copies, via the shared
+// version) fails CI rather than silently breaking Cedar evaluation.
+//
+//go:embed attest-tags-schema.json
+var canonicalTagsSchemaJSON []byte
+
+// TagSchemaEntry is one row of the canonical schema.
+type TagSchemaEntry struct {
+	Key    string `json:"key"`
+	Writer string `json:"writer"` // "qualify" | "attest" | "legacy"
+	Type   string `json:"type"`   // "bool" | "timestamp" | "string"
+	Module string `json:"module,omitempty"`
+	Expiry string `json:"expiry,omitempty"`
+}
+
+// TagSchema is the parsed canonical schema.
+type TagSchema struct {
+	Version   int              `json:"version"`
+	Namespace string           `json:"namespace"`
+	Tags      []TagSchemaEntry `json:"tags"`
+}
+
+// LoadTagSchema parses the embedded canonical attest:* tag schema.
+func LoadTagSchema() (*TagSchema, error) {
+	var s TagSchema
+	if err := json.Unmarshal(canonicalTagsSchemaJSON, &s); err != nil {
+		return nil, fmt.Errorf("parse canonical attest-tags-schema.json: %w", err)
+	}
+	return &s, nil
+}
+
 // attest:* IAM role tag key constants — authoritative schema for the attest side.
 //
 // qualify (github.com/provabl/qualify) writes these tags to researchers' IAM roles
 // on training completion. attest reads them via the principal resolver to populate
 // Cedar evaluation attributes.
 //
-// Schema version: 1
-//
 // IMPORTANT: Both qualify (internal/training/tags.go) and attest (this file) must
-// agree on these key strings. If any key changes, update BOTH repos in the same
-// release and increment the schema version comment.
+// agree on these key strings AND on SchemaVersion. The canonical contract is
+// attest-tags-schema.json (embedded above, byte-identical in both repos); the
+// conformance test locks these constants to it. If any key changes, update the
+// schema JSON in BOTH repos and bump SchemaVersion in the same release.
 // See: https://github.com/provabl/qualify/issues/32
 const (
 	// Training completion tags — written by qualify on module pass.

--- a/pkg/schema/tags_schema_test.go
+++ b/pkg/schema/tags_schema_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import (
+	"sort"
+	"testing"
+)
+
+// declaredTagConstants is every attest:* tag key constant declared in tags.go.
+// The conformance test below locks this set to the canonical schema, so adding,
+// removing, or renaming a constant without updating attest-tags-schema.json (and,
+// in the same release, qualify's byte-identical copy) fails CI. This is the guard
+// against the silent qualify↔attest drift described in qualify#32.
+var declaredTagConstants = []string{
+	TagCUITraining,
+	TagCUITrainingExpiry,
+	TagHIPAATraining,
+	TagHIPAATrainingExpiry,
+	TagAwarenessTraining,
+	TagAwarenessTrainingExpiry,
+	TagFERPATraining,
+	TagFERPATrainingExpiry,
+	TagITARTraining,
+	TagITARTrainingExpiry,
+	TagDataClassTraining,
+	TagDataClassTrainingExpiry,
+	TagResearchSecurityTraining,
+	TagResearchSecurityExpiry,
+	TagCOCCheckCurrent,
+	TagCOCCheckExpiry,
+	TagCountry,
+	TagNIHApproval,
+	TagNIHApprovalExpiry,
+	TagNIHDUAID,
+	TagLabID,
+	TagAdminLevel,
+	TagCUIExpiryLegacy,
+}
+
+// TestSchemaVersionMatchesCanonical guards that the Go SchemaVersion constant and
+// the embedded canonical schema agree. The same assertion in qualify (against its
+// byte-identical copy) is what makes SchemaVersion a meaningful cross-repo signal.
+func TestSchemaVersionMatchesCanonical(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+	if s.Version != SchemaVersion {
+		t.Errorf("canonical schema version = %d, SchemaVersion const = %d — bump them together", s.Version, SchemaVersion)
+	}
+	if s.Namespace != "attest:" {
+		t.Errorf("schema namespace = %q, want %q", s.Namespace, "attest:")
+	}
+}
+
+// TestDeclaredConstantsMatchSchema is the conformance test: the set of attest:* key
+// constants attest declares must be exactly the set of keys in the canonical schema
+// — no missing keys (attest can't read a tag it has no constant for) and no extra
+// keys (a constant with no schema entry is undocumented drift).
+func TestDeclaredConstantsMatchSchema(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+
+	schemaKeys := make(map[string]bool, len(s.Tags))
+	for _, e := range s.Tags {
+		if schemaKeys[e.Key] {
+			t.Errorf("duplicate key in schema: %q", e.Key)
+		}
+		schemaKeys[e.Key] = true
+	}
+
+	declared := make(map[string]bool, len(declaredTagConstants))
+	for _, k := range declaredTagConstants {
+		declared[k] = true
+	}
+
+	for k := range schemaKeys {
+		if !declared[k] {
+			t.Errorf("schema key %q has no attest constant — add it to tags.go and declaredTagConstants", k)
+		}
+	}
+	for k := range declared {
+		if !schemaKeys[k] {
+			t.Errorf("attest constant %q is not in the canonical schema — add it to attest-tags-schema.json (both repos) and bump SchemaVersion", k)
+		}
+	}
+
+	if len(declaredTagConstants) != len(s.Tags) {
+		got, want := dedupSorted(declaredTagConstants), schemaKeySlice(s)
+		t.Errorf("count mismatch: %d declared constants vs %d schema keys\n declared: %v\n schema:   %v", len(declaredTagConstants), len(s.Tags), got, want)
+	}
+}
+
+// TestSchemaEntriesWellFormed checks each entry has a known writer and type, and
+// that any referenced expiry/module key is itself a schema key (no dangling refs).
+func TestSchemaEntriesWellFormed(t *testing.T) {
+	s, err := LoadTagSchema()
+	if err != nil {
+		t.Fatalf("LoadTagSchema: %v", err)
+	}
+	keys := make(map[string]bool, len(s.Tags))
+	for _, e := range s.Tags {
+		keys[e.Key] = true
+	}
+	writers := map[string]bool{"qualify": true, "attest": true, "legacy": true}
+	types := map[string]bool{"bool": true, "timestamp": true, "string": true}
+	for _, e := range s.Tags {
+		if !writers[e.Writer] {
+			t.Errorf("%s: unknown writer %q", e.Key, e.Writer)
+		}
+		if !types[e.Type] {
+			t.Errorf("%s: unknown type %q", e.Key, e.Type)
+		}
+		if e.Expiry != "" && !keys[e.Expiry] {
+			t.Errorf("%s: expiry %q is not a schema key", e.Key, e.Expiry)
+		}
+	}
+}
+
+func dedupSorted(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func schemaKeySlice(s *TagSchema) []string {
+	out := make([]string, 0, len(s.Tags))
+	for _, e := range s.Tags {
+		out = append(out, e.Key)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
Closes the silent qualify↔attest tag-drift gap (provabl/qualify#32) — the **attest (reader) side**.

## Problem
The `attest:*` IAM tag namespace was defined independently in each repo. A rename on either side silently broke the other: qualify writes the new key, attest reads the old one, Cedar evaluates the attribute as *missing* rather than erroring.

## Approach (no build-time coupling)
attest still imports **no** `provabl/*` module — the products stay decoupled. The contract is a byte-identical canonical schema + a shared version, enforced by tests:
- **`pkg/schema/attest-tags-schema.json`** — canonical machine-readable schema (23 keys, `version: 1`), byte-identical with qualify's copy (same `shasum`). attest owns the `attest:` namespace.
- **`SchemaVersion` const** + embed/parse.
- **`pkg/schema/tags_schema_test.go`** — locks attest's declared `attest:*` constants to the schema keys (no missing, no extra), asserts `SchemaVersion` == schema version, and checks entries are well-formed. **Verified the guard fails CI on a renamed key** (not a no-op).
- **`docs/integrations/qualify.md`** — documents the schema, the drift guard, and the bump-both-and-increment rule; linked from the README.

## Companion
qualify side: provabl/qualify#43-equivalent PR (same branch name) — closes #32. Both carry the byte-identical schema; **merge together**.