### PR TITLE
feat(preflight): verify the caller holds attest's required IAM permissions (provabl#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`attest preflight` verifies the caller's IAM permissions** (provabl#16): a new check confirms the
+  calling principal actually holds the actions attest needs (Organizations read, `iam:ListRoleTags`/
+  `GetRole`/`ListRoles`, `cloudformation:DescribeStacks`, `cloudtrail:DescribeTrails`,
+  `config:DescribeConfigurationRecorders`, `sts:GetCallerIdentity`, and `iam:SimulatePrincipalPolicy`
+  itself) via read-only `iam:SimulatePrincipalPolicy` against the caller ARN from
+  `sts:GetCallerIdentity`. Each denied action is an error with a grant-this remediation and the
+  command flips to NOT READY. Fail-closed: an unresolvable caller or an un-callable simulator is an
+  error, not a pass. `internal/org.CheckCallerPermissions` (+ mock-driven tests). Complements the
+  existing org-posture checks (those ask "is the environment set up?"; this asks "can this principal
+  run attest here?"). Per-tool action lists live in the suite's `docs/required-permissions.md`; other
+  tools' preflight is tracked in provabl#16.
 - **Versioned `attest:*` tag schema contract** (qualify#32): the `attest:*` IAM tag namespace
   shared with qualify is now anchored by a canonical, machine-readable `pkg/schema/attest-tags-schema.json`
   (byte-identical with qualify's copy) plus a `SchemaVersion` constant. A conformance test

--- a/cmd/attest/main.go
+++ b/cmd/attest/main.go
@@ -32,24 +32,15 @@ import (
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
 	"github.com/provabl/attest/internal/ai"
-	"github.com/provabl/attest/internal/obligations"
-	"github.com/provabl/attest/internal/regulatory"
-	"github.com/provabl/attest/internal/auth"
-	"github.com/provabl/attest/internal/output"
-	"github.com/provabl/attest/internal/dashboard"
-	"github.com/provabl/attest/internal/document/cmmc"
-	"github.com/provabl/attest/internal/integrations/grc"
-	"github.com/provabl/attest/internal/multisre"
-	"github.com/provabl/attest/internal/principal"
-	"github.com/provabl/attest/internal/platform"
-	"github.com/provabl/attest/internal/workload"
-	"github.com/provabl/attest/internal/provision"
 	"github.com/provabl/attest/internal/artifact"
 	"github.com/provabl/attest/internal/attestation"
+	"github.com/provabl/attest/internal/auth"
 	compilerce "github.com/provabl/attest/internal/compiler/cedar"
 	compilerscp "github.com/provabl/attest/internal/compiler/scp"
+	"github.com/provabl/attest/internal/dashboard"
 	"github.com/provabl/attest/internal/deploy"
 	assessmentpkg "github.com/provabl/attest/internal/document/assessment"
+	"github.com/provabl/attest/internal/document/cmmc"
 	"github.com/provabl/attest/internal/document/dmsp"
 	osalexport "github.com/provabl/attest/internal/document/oscal"
 	"github.com/provabl/attest/internal/document/poam"
@@ -57,11 +48,20 @@ import (
 	"github.com/provabl/attest/internal/evaluator"
 	"github.com/provabl/attest/internal/framework"
 	"github.com/provabl/attest/internal/iac"
+	"github.com/provabl/attest/internal/integrations/grc"
+	"github.com/provabl/attest/internal/multisre"
+	"github.com/provabl/attest/internal/obligations"
 	"github.com/provabl/attest/internal/org"
+	"github.com/provabl/attest/internal/output"
+	"github.com/provabl/attest/internal/platform"
+	"github.com/provabl/attest/internal/principal"
+	"github.com/provabl/attest/internal/provision"
+	"github.com/provabl/attest/internal/regulatory"
 	"github.com/provabl/attest/internal/reporting"
 	"github.com/provabl/attest/internal/store"
 	attesttesting "github.com/provabl/attest/internal/testing"
 	"github.com/provabl/attest/internal/waiver"
+	"github.com/provabl/attest/internal/workload"
 	"github.com/provabl/attest/pkg/schema"
 )
 
@@ -880,7 +880,6 @@ func topoSort(ids []string, loaded map[string]*schema.Framework) []string {
 	return ordered
 }
 
-
 func compileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compile",
@@ -1103,9 +1102,9 @@ func buildCrosswalk(sre *schema.SRE, frameworks []*schema.Framework, scps []comp
 	for _, fw := range frameworks {
 		for _, ctrl := range fw.Controls {
 			entry := schema.CrosswalkEntry{
-				ControlID:   ctrl.ID,
-				FrameworkID: fw.ID,
-				SCPs:        scpsByControl[ctrl.ID],
+				ControlID:     ctrl.ID,
+				FrameworkID:   fw.ID,
+				SCPs:          scpsByControl[ctrl.ID],
 				CedarPolicies: cedarByControl[ctrl.ID],
 			}
 			switch {
@@ -1345,7 +1344,8 @@ func preflightCmd() *cobra.Command {
   - Organization feature set (ALL features required)
   - SCP policy type enabled on root
   - SCP quota: current usage vs. compiled SCP count
-  - IAM permissions for deployment
+  - IAM permissions: the calling principal holds attest's required actions
+    (checked via iam:SimulatePrincipalPolicy; see required-permissions.md)
 
 Run this before 'attest apply' to catch issues early.
 
@@ -1415,6 +1415,20 @@ that fit within this limit alongside the FullAWSAccess default policy.`,
 						} else {
 							pass("SCP quota: %d compiled, %d total after apply (within limit of %d)",
 								compiledCount, projectedTotal, deploy.SCPPerTargetLimit)
+						}
+					}
+				}
+			}
+
+			// Check 3: the calling principal holds attest's required IAM actions.
+			{
+				for _, r := range analyzer.CheckCallerPermissions(ctx) {
+					if r.Status {
+						pass("%s: %s", r.Name, r.Detail)
+					} else {
+						fail("%s: %s", r.Name, r.Detail)
+						if r.Remediation != "" {
+							output.Printf("      Remediation: %s\n", r.Remediation)
 						}
 					}
 				}
@@ -1620,7 +1634,6 @@ func loadCedarPolicies(dir string) (*cedar.PolicySet, error) {
 	}
 	return ps, nil
 }
-
 
 func generateCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -2335,7 +2348,7 @@ Assessment types:
 			level1Practices := map[string]bool{
 				"AC.L1-3.1.1": true, "AC.L1-3.1.2": true, "AC.L1-3.1.20": true, "AC.L1-3.1.22": true,
 				"IA.L1-3.5.1": true, "IA.L1-3.5.2": true,
-				"MP.L1-3.8.3": true,
+				"MP.L1-3.8.3":  true,
 				"PE.L1-3.10.1": true, "PE.L1-3.10.3": true, "PE.L1-3.10.4": true, "PE.L1-3.10.5": true,
 				"SC.L1-3.13.1": true, "SC.L1-3.13.5": true,
 				"SI.L1-3.14.1": true, "SI.L1-3.14.2": true,
@@ -2344,7 +2357,7 @@ Assessment types:
 			level1NistMap := map[string]string{
 				"AC.L1-3.1.1": "3.1.1", "AC.L1-3.1.2": "3.1.2", "AC.L1-3.1.20": "3.1.20", "AC.L1-3.1.22": "3.1.22",
 				"IA.L1-3.5.1": "3.5.1", "IA.L1-3.5.2": "3.5.2",
-				"MP.L1-3.8.3": "3.8.3",
+				"MP.L1-3.8.3":  "3.8.3",
 				"PE.L1-3.10.1": "3.10.1", "PE.L1-3.10.3": "3.10.3", "PE.L1-3.10.4": "3.10.4", "PE.L1-3.10.5": "3.10.5",
 				"SC.L1-3.13.1": "3.13.1", "SC.L1-3.13.5": "3.13.5",
 				"SI.L1-3.14.1": "3.14.1", "SI.L1-3.14.2": "3.14.2",
@@ -2470,14 +2483,14 @@ Output: .attest/documents/dmsp.md`,
 
 			plan := &dmsp.Plan{
 				SRE:             sre,
-				Crosswalk:        crosswalk,
-				PIName:           piName,
-				PIEmail:          piEmail,
-				GrantNumber:      grantNum,
-				InstitutionName:  institution,
-				ProjectTitle:     projectTitle,
-				FundingICCode:    icCode,
-				GeneratedAt:      time.Now(),
+				Crosswalk:       crosswalk,
+				PIName:          piName,
+				PIEmail:         piEmail,
+				GrantNumber:     grantNum,
+				InstitutionName: institution,
+				ProjectTitle:    projectTitle,
+				FundingICCode:   icCode,
+				GeneratedAt:     time.Now(),
 				// Default repositories for NIH research.
 				Repositories: []dmsp.Repository{
 					{Name: "dbGaP", URL: "https://www.ncbi.nlm.nih.gov/gap/", Access: "controlled", NIHDesignated: true},
@@ -2986,8 +2999,12 @@ Use 'attest ai translate' to generate proposed policies from natural language.`,
 
 			// Count policies.
 			currentCount, proposedCount := 0, 0
-			for range currentPS.All() { currentCount++ }
-			for range proposedPS.All() { proposedCount++ }
+			for range currentPS.All() {
+				currentCount++
+			}
+			for range proposedPS.All() {
+				proposedCount++
+			}
 			output.Printf("Simulating: %d current vs %d proposed policies\n", currentCount, proposedCount)
 			output.Printf("CloudTrail window: last %d hour(s) (region: %s)\n\n", hours, region)
 
@@ -3018,9 +3035,13 @@ Use 'attest ai translate' to generate proposed policies from natural language.`,
 					continue
 				}
 				cur, err := eval.EvaluateWithPolicies(ctx, currentPS, req)
-				if err != nil { continue }
+				if err != nil {
+					continue
+				}
 				prop, err := eval.EvaluateWithPolicies(ctx, proposedPS, req)
-				if err != nil { continue }
+				if err != nil {
+					continue
+				}
 
 				if cur.Effect == prop.Effect {
 					unchanged++
@@ -5873,16 +5894,16 @@ Requires: cosign CLI installed (https://docs.sigstore.dev/cosign/system_config/i
 				// (come from the signed image's attestation) and must not be
 				// interpolated into a raw YAML string.
 				draftRecord := map[string]string{
-					"id":             draftID,
-					"control_id":     m.ControlID,
-					"objective_id":   m.ObjectiveID,
-					"title":          m.Description,
-					"affirmed_by":    "cosign-automated",
-					"evidence":       m.Evidence,
-					"evidence_type":  "cosign_attestation",
-					"rekor_log_id":   att.RekorLogID,
-					"sbom_digest":    att.SBOMDigest,
-					"status":         "draft",
+					"id":            draftID,
+					"control_id":    m.ControlID,
+					"objective_id":  m.ObjectiveID,
+					"title":         m.Description,
+					"affirmed_by":   "cosign-automated",
+					"evidence":      m.Evidence,
+					"evidence_type": "cosign_attestation",
+					"rekor_log_id":  att.RekorLogID,
+					"sbom_digest":   att.SBOMDigest,
+					"status":        "draft",
 				}
 				draftBytes, err := yaml.Marshal(draftRecord)
 				if err != nil {
@@ -6057,8 +6078,8 @@ Requires: cloudtrail:DescribeTrails, events:PutRule, events:PutTargets,
 			queueOut, err := sqsSvc.CreateQueue(ctx, &sqssvc.CreateQueueInput{
 				QueueName: aws.String("attest-cedar-events"),
 				Attributes: map[string]string{
-					"MessageRetentionPeriod":  "86400",  // 1 day
-					"VisibilityTimeout":        "60",
+					"MessageRetentionPeriod":        "86400", // 1 day
+					"VisibilityTimeout":             "60",
 					"ReceiveMessageWaitTimeSeconds": "20", // enable long-polling by default
 				},
 			})
@@ -6081,8 +6102,8 @@ Requires: cloudtrail:DescribeTrails, events:PutRule, events:PutTargets,
 			// Create EventBridge rule.
 			ebSvc := ebsvc.NewFromConfig(cfg)
 			ruleOut, err := ebSvc.PutRule(ctx, &ebsvc.PutRuleInput{
-				Name:        aws.String("attest-cedar-cloudtrail"),
-				Description: aws.String("Delivers CloudTrail management events to attest Cedar PDP"),
+				Name:         aws.String("attest-cedar-cloudtrail"),
+				Description:  aws.String("Delivers CloudTrail management events to attest Cedar PDP"),
 				EventPattern: aws.String(`{"source":["aws.cloudtrail"]}`),
 				State:        ebtypes.RuleStateEnabled,
 			})

--- a/internal/org/prerequisites.go
+++ b/internal/org/prerequisites.go
@@ -12,8 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	cttrail "github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // PrereqResult is the outcome of a single prerequisite check.
@@ -37,27 +40,27 @@ type PrereqResult struct {
 // ground does not deploy detection services. attest manages GuardDuty, Security Hub,
 // and Macie based on active compliance frameworks via 'attest compile' + 'attest apply'.
 type GroundMeta struct {
-	GroundVersion             string            `json:"ground_version"`
-	Region                    string            `json:"region"`
-	CloudTrailEnabled         bool              `json:"cloudtrail_enabled"`
-	ConfigEnabled             bool              `json:"config_enabled"`
-	LogArchiveAccountID       string            `json:"log_archive_account_id,omitempty"`
-	IdentityCenterInstanceARN string            `json:"identity_center_instance_arn,omitempty"`
+	GroundVersion             string `json:"ground_version"`
+	Region                    string `json:"region"`
+	CloudTrailEnabled         bool   `json:"cloudtrail_enabled"`
+	ConfigEnabled             bool   `json:"config_enabled"`
+	LogArchiveAccountID       string `json:"log_archive_account_id,omitempty"`
+	IdentityCenterInstanceARN string `json:"identity_center_instance_arn,omitempty"`
 	// ExternalServices lists non-AWS services declared in ground.yaml.
 	// attest uses these to assess controls satisfied by those services.
-	ExternalServices          []ExternalService `json:"external_services,omitempty"`
+	ExternalServices []ExternalService `json:"external_services,omitempty"`
 }
 
 // ExternalService is a non-AWS service deployed in the SRE (from ground.yaml).
 // Category: edr, siem, cspm, cwpp, data-transfer, vuln-scanning, identity, research-platform
 // Features: fedramp-high, fedramp-moderate, baa, hipaa-compliant, high-assurance, soc2-type2
 type ExternalService struct {
-	Name        string         `json:"name"`
-	Vendor      string         `json:"vendor"`
-	Category    string         `json:"category"`
-	Features    []string       `json:"features,omitempty"`
-	Scope       []string       `json:"scope,omitempty"` // OU names; empty = org-wide
-	Notes       string         `json:"notes,omitempty"`
+	Name     string   `json:"name"`
+	Vendor   string   `json:"vendor"`
+	Category string   `json:"category"`
+	Features []string `json:"features,omitempty"`
+	Scope    []string `json:"scope,omitempty"` // OU names; empty = org-wide
+	Notes    string   `json:"notes,omitempty"`
 	// Probe and ProbeConfig mirror the ground.yaml fields so probe declarations
 	// survive round-trip through ground-meta.json without silent field loss.
 	Probe       string         `json:"probe,omitempty"`
@@ -280,6 +283,118 @@ func checkIdentityCenter(ctx context.Context, ssoAdmin *ssoadmin.Client) PrereqR
 		Status:   true,
 		Detail:   instanceArn + " (will be auto-added to SSP system boundary)",
 	}
+}
+
+// --- caller-permission preflight (provabl#16) ---------------------------------
+
+// stsIdentityAPI is the subset of the STS client used to resolve the caller ARN.
+// An interface so tests can supply a fake (mirrors the configAPI precedent).
+type stsIdentityAPI interface {
+	GetCallerIdentity(ctx context.Context, in *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// iamSimAPI is the subset of the IAM client used to simulate the caller's policies.
+type iamSimAPI interface {
+	SimulatePrincipalPolicy(ctx context.Context, in *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// attestRequiredActions are the AWS IAM actions attest itself needs to run its
+// core read/eval flow (init, scan, principal resolution, posture). Sourced from
+// provabl/docs/required-permissions.md (attest row) and attest's real SDK calls.
+// Kept to the read/eval core: the continuous-evaluation write path (eventbridge,
+// sqs) and the AI navigator (bedrock) are optional/commercial and not gated here.
+// iam:SimulatePrincipalPolicy is included because the preflight itself needs it.
+var attestRequiredActions = []string{
+	"sts:GetCallerIdentity",
+	"organizations:DescribeOrganization",
+	"organizations:ListRoots",
+	"iam:ListRoles",
+	"iam:GetRole",
+	"iam:ListRoleTags",
+	"iam:SimulatePrincipalPolicy",
+	"cloudformation:DescribeStacks",
+	"cloudtrail:DescribeTrails",
+	"config:DescribeConfigurationRecorders",
+}
+
+// CheckCallerPermissions verifies the calling principal holds the IAM actions
+// attest needs, via iam:SimulatePrincipalPolicy (read-only — it evaluates, it does
+// not act). It complements the org-posture checks: those ask "is the environment
+// set up?"; this asks "can the principal running attest actually do its work here?"
+// Other suite tools' permissions are documented in required-permissions.md and
+// tracked in provabl#16.
+//
+// Fail-closed: if the caller ARN can't be resolved or the simulator can't be
+// called, that is an error result (not a silent pass) — an un-checkable
+// environment is treated as not-ready.
+func (a *Analyzer) CheckCallerPermissions(ctx context.Context) []PrereqResult {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(func() string {
+		if a.region != "" {
+			return a.region
+		}
+		return "us-east-1"
+	}()))
+	if err != nil {
+		return []PrereqResult{{
+			Name: "AWS credentials", Severity: "error", Status: false,
+			Detail:      err.Error(),
+			Remediation: "Configure AWS credentials: aws configure or set AWS_PROFILE",
+		}}
+	}
+	return checkCallerPermissions(ctx, sts.NewFromConfig(cfg), iam.NewFromConfig(cfg))
+}
+
+// checkCallerPermissions is the testable core: resolve the caller ARN, simulate
+// the required actions against it, and map the result to PrereqResults.
+func checkCallerPermissions(ctx context.Context, stsSvc stsIdentityAPI, iamSvc iamSimAPI) []PrereqResult {
+	ident, err := stsSvc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return []PrereqResult{{
+			Name: "Caller identity", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("sts:GetCallerIdentity failed: %v", err),
+			Remediation: "Ensure valid AWS credentials with sts:GetCallerIdentity",
+		}}
+	}
+	callerARN := aws.ToString(ident.Arn)
+
+	out, err := iamSvc.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(callerARN),
+		ActionNames:     attestRequiredActions,
+	})
+	if err != nil {
+		// Fail-closed: an un-runnable self-check is an error, not a pass.
+		return []PrereqResult{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("iam:SimulatePrincipalPolicy failed for %s: %v", callerARN, err),
+			Remediation: "Grant iam:SimulatePrincipalPolicy to run the permission preflight (or review required-permissions.md manually)",
+		}}
+	}
+
+	// One result per evaluated action: allowed → ok, any deny → error.
+	var results []PrereqResult
+	for _, ev := range out.EvaluationResults {
+		action := aws.ToString(ev.EvalActionName)
+		if ev.EvalDecision == iamtypes.PolicyEvaluationDecisionTypeAllowed {
+			results = append(results, PrereqResult{
+				Name: "IAM: " + action, Severity: "ok", Status: true, Detail: "allowed",
+			})
+			continue
+		}
+		results = append(results, PrereqResult{
+			Name: "IAM: " + action, Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("%s for %s", string(ev.EvalDecision), callerARN),
+			Remediation: "Grant " + action + " to the attest principal (see required-permissions.md)",
+		})
+	}
+	if len(results) == 0 {
+		// No evaluation results at all is itself a fail-closed condition.
+		return []PrereqResult{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      "simulator returned no evaluation results",
+			Remediation: "Review required-permissions.md and the attest principal's policy",
+		}}
+	}
+	return results
 }
 
 // --- helpers ------------------------------------------------------------------

--- a/internal/org/prerequisites_test.go
+++ b/internal/org/prerequisites_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package org
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type mockSTS struct {
+	arn string
+	err error
+}
+
+func (m mockSTS) GetCallerIdentity(_ context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sts.GetCallerIdentityOutput{Arn: aws.String(m.arn)}, nil
+}
+
+type mockIAMSim struct {
+	// deniedActions are returned as explicitDeny; all others as allowed.
+	deniedActions map[string]bool
+	err           error
+}
+
+func (m mockIAMSim) SimulatePrincipalPolicy(_ context.Context, in *iam.SimulatePrincipalPolicyInput, _ ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var results []iamtypes.EvaluationResult
+	for _, a := range in.ActionNames {
+		dec := iamtypes.PolicyEvaluationDecisionTypeAllowed
+		if m.deniedActions[a] {
+			dec = iamtypes.PolicyEvaluationDecisionTypeExplicitDeny
+		}
+		results = append(results, iamtypes.EvaluationResult{
+			EvalActionName: aws.String(a),
+			EvalDecision:   dec,
+		})
+	}
+	return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+}
+
+const testCallerARN = "arn:aws:iam::942542972736:role/attest-runner"
+
+func allOK(t *testing.T, results []PrereqResult) bool {
+	t.Helper()
+	for _, r := range results {
+		if !r.Status {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCheckCallerPermissions_AllAllowed(t *testing.T) {
+	results := checkCallerPermissions(context.Background(),
+		mockSTS{arn: testCallerARN}, mockIAMSim{})
+	if len(results) != len(attestRequiredActions) {
+		t.Fatalf("expected %d results (one per action), got %d", len(attestRequiredActions), len(results))
+	}
+	if !allOK(t, results) {
+		t.Error("expected all actions allowed → all ok")
+	}
+}
+
+// The core case: a denied action must surface as a non-ok result with remediation,
+// so preflight flips to NOT READY (fail-closed on missing permission).
+func TestCheckCallerPermissions_DeniedActionIsError(t *testing.T) {
+	results := checkCallerPermissions(context.Background(),
+		mockSTS{arn: testCallerARN},
+		mockIAMSim{deniedActions: map[string]bool{"iam:ListRoleTags": true}})
+
+	var found bool
+	for _, r := range results {
+		if r.Name == "IAM: iam:ListRoleTags" {
+			found = true
+			if r.Status {
+				t.Error("denied action must be a non-ok result")
+			}
+			if r.Severity != "error" {
+				t.Errorf("denied action severity = %q, want error", r.Severity)
+			}
+			if r.Remediation == "" {
+				t.Error("denied action must carry a remediation")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no result for the denied action iam:ListRoleTags")
+	}
+	if allOK(t, results) {
+		t.Error("a denied action must make the overall set not-all-ok")
+	}
+}
+
+func TestCheckCallerPermissions_CallerIdentityErrorFailsClosed(t *testing.T) {
+	results := checkCallerPermissions(context.Background(),
+		mockSTS{err: errors.New("ExpiredToken")}, mockIAMSim{})
+	if len(results) != 1 || results[0].Status {
+		t.Fatalf("expected a single error result on GetCallerIdentity failure, got %+v", results)
+	}
+}
+
+// A simulator API failure must NOT be read as "permitted" — it's fail-closed.
+func TestCheckCallerPermissions_SimulatorErrorFailsClosed(t *testing.T) {
+	results := checkCallerPermissions(context.Background(),
+		mockSTS{arn: testCallerARN}, mockIAMSim{err: errors.New("AccessDenied")})
+	if len(results) != 1 || results[0].Status {
+		t.Fatalf("expected a single fail-closed error result on simulator failure, got %+v", results)
+	}
+	if results[0].Remediation == "" {
+		t.Error("fail-closed result should explain how to enable the self-check")
+	}
+}


### PR DESCRIPTION
`attest preflight` now verifies the **calling principal can actually perform attest's actions** — not just that the org is set up. This fills a gap the command's own `Long` text advertised ("IAM permissions for deployment") but never checked.

## What's here
- **`internal/org.CheckCallerPermissions`** — resolves the caller ARN (`sts:GetCallerIdentity`) and simulates attest's required actions against it via **read-only `iam:SimulatePrincipalPolicy`** (the principal-side sibling of the `SimulateCustomPolicy` the SCP-adversarial test uses). Allowed → ok; any deny → error + grant-this remediation. **Fail-closed**: an unresolvable caller or an un-callable simulator is an error, not a pass. Mockable via small iam/sts interfaces (the `configAPI` precedent).
- **`cmd/attest preflight`** — renders it as "Check 3" beside org-features + SCP-quota, NOT READY on any deny. `Long` corrected.
- **Tests** — all-allowed, denied-action→error+remediation, caller-id failure fail-closed, simulator failure fail-closed (the deny + fail-closed paths are the ones that matter).

## Verified live (read-only)
`attest preflight` against a real account reported all 10 attest actions `allowed` alongside the existing org/SCP checks. No spend.

## Scope
Checks **attest's own** actions (the principal running attest). The other suite tools doing the same is the remaining work on **provabl#16**; the per-tool lists are in `provabl/docs/required-permissions.md`.

Refs: provabl#16