### PR TITLE
feat(approval): attest approval grant/revoke — NIH DUA lifecycle (attest#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`attest approval grant`/`revoke`** — the NIH DUA approval lifecycle (attest#99; provabl#11 Tier 2,
+  ADR 0002 Decision 2). `grant` records a signed DUA as a human-affirmed `schema.Attestation`, then
+  *activates* it by writing the `attest:nih-approval`, `attest:nih-approval-expiry`, and
+  `attest:nih-dua-ids` IAM role tags the principal resolver reads and `cedar-nih-approved-user` gates
+  on — no new evaluation path. Because a researcher accrues DUAs across studies (and compute-to-data
+  binds each dataset to a specific DUA), `grant` **merges** the DUA into the `attest:nih-dua-ids` set
+  and `revoke` removes one, clearing the approval tags entirely when the last is gone (never leaving
+  `attest:nih-approval=true` with an empty set — an inconsistent state). New `internal/approval`
+  (set-merge logic behind an injectable `RoleTagger`; fake-driven tests). Records first, then touches
+  IAM — no activation without a recorded basis. This is attest's first IAM-role-*write* path; it adds
+  `iam:TagRole`/`iam:UntagRole` (documented in the suite's `docs/required-permissions.md` as
+  approval-only). The dataset-scoped Cedar policy that *consumes* the set is the follow-up (attest#100).
 - **`attest preflight` verifies the caller's IAM permissions** (provabl#16): a new check confirms the
   calling principal actually holds the actions attest needs (Organizations read, `iam:ListRoleTags`/
   `GetRole`/`ListRoles`, `cloudformation:DescribeStacks`, `cloudtrail:DescribeTrails`,

--- a/cmd/attest/main.go
+++ b/cmd/attest/main.go
@@ -28,10 +28,12 @@ import (
 	ebsvc "github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	iamSvc "github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	sqssvc "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
 	"github.com/provabl/attest/internal/ai"
+	"github.com/provabl/attest/internal/approval"
 	"github.com/provabl/attest/internal/artifact"
 	"github.com/provabl/attest/internal/attestation"
 	"github.com/provabl/attest/internal/auth"
@@ -99,6 +101,7 @@ within it are research environments that inherit the org-level posture.`,
 		waiverCmd(),
 		incidentCmd(),
 		attestCmd(),
+		approvalCmd(),
 		calendarCmd(),
 		reportCmd(),
 		aiCmd(),
@@ -3785,6 +3788,184 @@ PI personal attestation on Data Use Certifications.`,
 	_ = piSignCmd.MarkFlagRequired("expires")
 
 	cmd.AddCommand(createCmd, listCmd, expireCmd, piSignCmd)
+	return cmd
+}
+
+// roleNameFromARN extracts the role name from an IAM role ARN, or returns the
+// input unchanged if it is already a bare role name (no ":role/").
+func roleNameFromARN(arn string) string {
+	const sep = ":role/"
+	if i := strings.LastIndex(arn, sep); i != -1 {
+		name := arn[i+len(sep):]
+		// Strip any path prefix ("admin/Researcher" → "Researcher").
+		if j := strings.LastIndex(name, "/"); j != -1 {
+			name = name[j+1:]
+		}
+		return name
+	}
+	return arn
+}
+
+// iamRoleTagger adapts the AWS IAM client to approval.RoleTagger.
+type iamRoleTagger struct{ client *iamSvc.Client }
+
+func (t *iamRoleTagger) ListRoleTags(ctx context.Context, roleName string) (map[string]string, error) {
+	tags := map[string]string{}
+	var marker *string
+	for {
+		out, err := t.client.ListRoleTags(ctx, &iamSvc.ListRoleTagsInput{RoleName: aws.String(roleName), Marker: marker})
+		if err != nil {
+			return nil, err
+		}
+		for _, tg := range out.Tags {
+			tags[aws.ToString(tg.Key)] = aws.ToString(tg.Value)
+		}
+		if !out.IsTruncated {
+			return tags, nil
+		}
+		marker = out.Marker
+	}
+}
+
+func (t *iamRoleTagger) TagRole(ctx context.Context, roleName string, tags map[string]string) error {
+	in := &iamSvc.TagRoleInput{RoleName: aws.String(roleName)}
+	for k, v := range tags {
+		in.Tags = append(in.Tags, iamtypes.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	_, err := t.client.TagRole(ctx, in)
+	return err
+}
+
+func (t *iamRoleTagger) UntagRole(ctx context.Context, roleName string, keys []string) error {
+	_, err := t.client.UntagRole(ctx, &iamSvc.UntagRoleInput{RoleName: aws.String(roleName), TagKeys: keys})
+	return err
+}
+
+// approvalCmd records and activates NIH DUA approvals on a researcher's IAM role.
+// "Record" persists a human-affirmed schema.Attestation; "activate" writes the
+// attest:nih-* tags the principal resolver reads and cedar-nih-approved-user gates
+// on. The approved DUAs are a set (attest:nih-dua-ids), so grant MERGES and revoke
+// removes one — see internal/approval and provabl ADR 0002 (compute-to-data).
+func approvalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "approval",
+		Short: "Record and activate NIH DUA approvals on a researcher's IAM role",
+		Long: `Grant or revoke an NIH Data Use Agreement (DUA) approval for a researcher.
+
+grant records a signed DUA as a human-affirmed attestation and activates it by
+writing the attest:nih-approval, attest:nih-approval-expiry, and attest:nih-dua-ids
+tags on the researcher's IAM role. A researcher holds DUAs for multiple studies, so
+grant MERGES the DUA into the existing attest:nih-dua-ids set (compute-to-data binds
+each dataset to a specific DUA). revoke removes one DUA, clearing the approval tags
+entirely when the last one is removed.
+
+Requires iam:ListRoleTags, iam:TagRole, and iam:UntagRole on the target role.`,
+	}
+
+	newTagger := func(ctx context.Context, region string) (*iamRoleTagger, error) {
+		cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+		if err != nil {
+			return nil, fmt.Errorf("load AWS config: %w", err)
+		}
+		return &iamRoleTagger{client: iamSvc.NewFromConfig(cfg)}, nil
+	}
+
+	attDir := filepath.Join(".attest", "attestations")
+	mgr := attestation.NewManager(attDir)
+
+	grantCmd := &cobra.Command{
+		Use:   "grant",
+		Short: "Grant (or extend) an NIH DUA approval and activate it",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			roleARN, _ := cmd.Flags().GetString("role")
+			dua, _ := cmd.Flags().GetString("dua")
+			affirmedBy, _ := cmd.Flags().GetString("affirmed-by")
+			expiresStr, _ := cmd.Flags().GetString("expires")
+			region, _ := cmd.Flags().GetString("region")
+			evidenceRef, _ := cmd.Flags().GetString("evidence")
+
+			expires, err := time.Parse("2006-01-02", expiresStr)
+			if err != nil {
+				return fmt.Errorf("invalid --expires date (use YYYY-MM-DD): %w", err)
+			}
+
+			// Record first: a durable, human-affirmed attestation of the DUA. If
+			// the record can't be written we do not touch IAM (no silent activation
+			// without a recorded basis).
+			att := &schema.Attestation{
+				ID:           fmt.Sprintf("DUA-%d-%s", time.Now().Year(), strings.ToUpper(strings.ReplaceAll(dua, ".", ""))),
+				ControlID:    "nih-gds-1.1",
+				Title:        fmt.Sprintf("NIH DUA approval: %s", dua),
+				AffirmedBy:   affirmedBy,
+				ExpiresAt:    expires,
+				EvidenceRef:  evidenceRef,
+				EvidenceType: "manual",
+				Notes:        fmt.Sprintf("DUA %s; role %s", dua, roleARN),
+			}
+			if err := mgr.Create(ctx, att); err != nil {
+				return fmt.Errorf("recording approval attestation: %w", err)
+			}
+
+			// Activate: merge the DUA into the role's attest:nih-dua-ids set.
+			tagger, err := newTagger(ctx, region)
+			if err != nil {
+				return err
+			}
+			set, err := approval.Grant(ctx, tagger, roleNameFromARN(roleARN), dua, expires)
+			if err != nil {
+				return err
+			}
+			output.Printf("✓ Recorded attestation %s and activated DUA %s\n", att.ID, dua)
+			output.Printf("  Role %s now approved for: %s (expires %s)\n",
+				roleNameFromARN(roleARN), strings.Join(set, ", "), expires.Format("2006-01-02"))
+			return nil
+		},
+	}
+	grantCmd.Flags().String("role", "", "Researcher IAM role ARN or name (required)")
+	grantCmd.Flags().String("dua", "", "DUA / dbGaP study id, e.g. phs000178 (required)")
+	grantCmd.Flags().String("affirmed-by", "", "Who affirmed the signed DUA (required)")
+	grantCmd.Flags().String("expires", "", "DUA term end YYYY-MM-DD (required)")
+	grantCmd.Flags().String("evidence", "", "Reference to the signed DUA (path/URL)")
+	grantCmd.Flags().String("region", "us-east-1", "AWS region for IAM tagging")
+	_ = grantCmd.MarkFlagRequired("role")
+	_ = grantCmd.MarkFlagRequired("dua")
+	_ = grantCmd.MarkFlagRequired("affirmed-by")
+	_ = grantCmd.MarkFlagRequired("expires")
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke one NIH DUA approval (clears all approval tags when the last is removed)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			roleARN, _ := cmd.Flags().GetString("role")
+			dua, _ := cmd.Flags().GetString("dua")
+			region, _ := cmd.Flags().GetString("region")
+
+			tagger, err := newTagger(ctx, region)
+			if err != nil {
+				return err
+			}
+			set, err := approval.Revoke(ctx, tagger, roleNameFromARN(roleARN), dua)
+			if err != nil {
+				return err
+			}
+			if len(set) == 0 {
+				output.Printf("✓ Revoked DUA %s; %s is no longer an NIH approved user (approval tags cleared)\n",
+					dua, roleNameFromARN(roleARN))
+			} else {
+				output.Printf("✓ Revoked DUA %s; role still approved for: %s\n", dua, strings.Join(set, ", "))
+			}
+			return nil
+		},
+	}
+	revokeCmd.Flags().String("role", "", "Researcher IAM role ARN or name (required)")
+	revokeCmd.Flags().String("dua", "", "DUA / dbGaP study id to revoke (required)")
+	revokeCmd.Flags().String("region", "us-east-1", "AWS region for IAM tagging")
+	_ = revokeCmd.MarkFlagRequired("role")
+	_ = revokeCmd.MarkFlagRequired("dua")
+
+	cmd.AddCommand(grantCmd, revokeCmd)
 	return cmd
 }
 

--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package approval activates an NIH DUA / IRB approval on a researcher's IAM
+// role: it writes the attest:nih-* tags the principal resolver reads and the
+// cedar-nih-approved-user policy gates on. This is the "activate" half of the
+// approval lifecycle (attest#99); the durable, human-affirmed record is a
+// schema.Attestation managed separately (internal/attestation).
+//
+// The load-bearing detail is the DUA set. A researcher accrues DUAs for multiple
+// studies, and compute-to-data (attest#100) binds each controlled dataset to a
+// specific DUA via principal.nih_approval_dua_ids.contains(resource.dua_id). So
+// granting a DUA MERGES into the existing attest:nih-dua-ids set rather than
+// overwriting it, and revoking removes exactly one member. The set is carried in
+// one IAM tag value, SetDelim-joined (see schema.SetDelim — '+', because a comma
+// is not a valid IAM tag-value character).
+package approval
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/provabl/attest/pkg/schema"
+)
+
+// RoleTagger reads and writes a role's tags. Implemented by the AWS IAM client in
+// production (cmd/attest), faked in tests. The three methods map to
+// iam:ListRoleTags / iam:TagRole / iam:UntagRole.
+type RoleTagger interface {
+	ListRoleTags(ctx context.Context, roleName string) (map[string]string, error)
+	TagRole(ctx context.Context, roleName string, tags map[string]string) error
+	UntagRole(ctx context.Context, roleName string, keys []string) error
+}
+
+// Grant activates (or extends) NIH Approved-User status on roleName for one DUA:
+// it sets attest:nih-approval=true and attest:nih-approval-expiry, and MERGES
+// duaID into the attest:nih-dua-ids set. It returns the resulting DUA set.
+//
+// Idempotent: granting a DUA already present is a no-op for the set. The expiry
+// is always (re)written — extending one DUA refreshes the principal's approval
+// horizon, which is the intended semantics (access is also bounded per-dataset by
+// the dataset's own DUA, enforced in Cedar).
+func Grant(ctx context.Context, t RoleTagger, roleName, duaID string, expires time.Time) ([]string, error) {
+	if roleName == "" {
+		return nil, fmt.Errorf("role name is required")
+	}
+	if err := validateDUAID(duaID); err != nil {
+		return nil, err
+	}
+	if expires.IsZero() {
+		return nil, fmt.Errorf("an expiry date is required (DUAs are time-bounded)")
+	}
+
+	current, err := t.ListRoleTags(ctx, roleName)
+	if err != nil {
+		return nil, fmt.Errorf("read current tags for %s: %w", roleName, err)
+	}
+
+	set := parseSet(current[schema.TagNIHDUAIDs])
+	set = addToSet(set, duaID)
+
+	tags := map[string]string{
+		schema.TagNIHApproval:       "true",
+		schema.TagNIHApprovalExpiry: expires.UTC().Format(time.RFC3339),
+		schema.TagNIHDUAIDs:         joinSet(set),
+	}
+	if err := t.TagRole(ctx, roleName, tags); err != nil {
+		return nil, fmt.Errorf("write approval tags to %s: %w", roleName, err)
+	}
+	return set, nil
+}
+
+// Revoke removes duaID from the role's attest:nih-dua-ids set. When the last DUA
+// is removed it also clears attest:nih-approval (the principal is no longer an
+// approved user of any study) by deleting the approval tags outright. It returns
+// the remaining DUA set.
+func Revoke(ctx context.Context, t RoleTagger, roleName, duaID string) ([]string, error) {
+	if roleName == "" {
+		return nil, fmt.Errorf("role name is required")
+	}
+	if err := validateDUAID(duaID); err != nil {
+		return nil, err
+	}
+
+	current, err := t.ListRoleTags(ctx, roleName)
+	if err != nil {
+		return nil, fmt.Errorf("read current tags for %s: %w", roleName, err)
+	}
+
+	set := removeFromSet(parseSet(current[schema.TagNIHDUAIDs]), duaID)
+
+	if len(set) == 0 {
+		// No DUAs left → not an approved user. Remove the approval tags entirely
+		// rather than leaving attest:nih-approval=true with an empty DUA set
+		// (which would pass the blanket gate but fail every dataset-scoped check —
+		// an inconsistent state we refuse to write).
+		keys := []string{schema.TagNIHApproval, schema.TagNIHApprovalExpiry, schema.TagNIHDUAIDs}
+		if err := t.UntagRole(ctx, roleName, keys); err != nil {
+			return nil, fmt.Errorf("clear approval tags on %s: %w", roleName, err)
+		}
+		return nil, nil
+	}
+
+	if err := t.TagRole(ctx, roleName, map[string]string{schema.TagNIHDUAIDs: joinSet(set)}); err != nil {
+		return nil, fmt.Errorf("update DUA set on %s: %w", roleName, err)
+	}
+	return set, nil
+}
+
+// validateDUAID rejects an empty id and one containing the set delimiter (which
+// would split into phantom members on read).
+func validateDUAID(duaID string) error {
+	if strings.TrimSpace(duaID) == "" {
+		return fmt.Errorf("a DUA / study id is required")
+	}
+	if strings.Contains(duaID, schema.SetDelim) {
+		return fmt.Errorf("DUA id %q must not contain the set delimiter %q", duaID, schema.SetDelim)
+	}
+	return nil
+}
+
+// parseSet splits a SetDelim-joined value into trimmed, non-empty members.
+func parseSet(v string) []string {
+	var out []string
+	for _, m := range strings.Split(v, schema.SetDelim) {
+		if m = strings.TrimSpace(m); m != "" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// joinSet renders members back into the single tag value, sorted for a stable,
+// diff-friendly result.
+func joinSet(members []string) string {
+	sort.Strings(members)
+	return strings.Join(members, schema.SetDelim)
+}
+
+func addToSet(set []string, member string) []string {
+	for _, m := range set {
+		if m == member {
+			return set
+		}
+	}
+	return append(set, member)
+}
+
+func removeFromSet(set []string, member string) []string {
+	out := set[:0:0]
+	for _, m := range set {
+		if m != member {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/approval/approval_test.go
+++ b/internal/approval/approval_test.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package approval
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/provabl/attest/pkg/schema"
+)
+
+// fakeTagger is an in-memory RoleTagger keyed by role name.
+type fakeTagger struct {
+	tags    map[string]map[string]string
+	listErr error
+	tagErr  error
+}
+
+func newFakeTagger(initial map[string]string) *fakeTagger {
+	t := &fakeTagger{tags: map[string]map[string]string{"researcher": {}}}
+	for k, v := range initial {
+		t.tags["researcher"][k] = v
+	}
+	return t
+}
+
+func (f *fakeTagger) ListRoleTags(_ context.Context, role string) (map[string]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := map[string]string{}
+	for k, v := range f.tags[role] {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (f *fakeTagger) TagRole(_ context.Context, role string, tags map[string]string) error {
+	if f.tagErr != nil {
+		return f.tagErr
+	}
+	if f.tags[role] == nil {
+		f.tags[role] = map[string]string{}
+	}
+	for k, v := range tags {
+		f.tags[role][k] = v
+	}
+	return nil
+}
+
+func (f *fakeTagger) UntagRole(_ context.Context, role string, keys []string) error {
+	for _, k := range keys {
+		delete(f.tags[role], k)
+	}
+	return nil
+}
+
+var expiry = time.Date(2027, 5, 1, 0, 0, 0, 0, time.UTC)
+
+func TestGrant_FirstDUA(t *testing.T) {
+	f := newFakeTagger(nil)
+	set, err := Grant(context.Background(), f, "researcher", "phs000178", expiry)
+	if err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if !reflect.DeepEqual(set, []string{"phs000178"}) {
+		t.Errorf("set = %v, want [phs000178]", set)
+	}
+	got := f.tags["researcher"]
+	if got[schema.TagNIHApproval] != "true" {
+		t.Errorf("%s = %q, want true", schema.TagNIHApproval, got[schema.TagNIHApproval])
+	}
+	if got[schema.TagNIHDUAIDs] != "phs000178" {
+		t.Errorf("%s = %q, want phs000178", schema.TagNIHDUAIDs, got[schema.TagNIHDUAIDs])
+	}
+	if got[schema.TagNIHApprovalExpiry] != "2027-05-01T00:00:00Z" {
+		t.Errorf("expiry = %q, want 2027-05-01T00:00:00Z", got[schema.TagNIHApprovalExpiry])
+	}
+}
+
+func TestGrant_MergesIntoExistingSet(t *testing.T) {
+	f := newFakeTagger(map[string]string{
+		schema.TagNIHApproval: "true",
+		schema.TagNIHDUAIDs:   "phs000178",
+	})
+	set, err := Grant(context.Background(), f, "researcher", "phs000200", expiry)
+	if err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	want := []string{"phs000178", "phs000200"} // sorted
+	if !reflect.DeepEqual(set, want) {
+		t.Errorf("set = %v, want %v", set, want)
+	}
+	if got := f.tags["researcher"][schema.TagNIHDUAIDs]; got != "phs000178+phs000200" {
+		t.Errorf("tag value = %q, want phs000178+phs000200", got)
+	}
+}
+
+func TestGrant_Idempotent(t *testing.T) {
+	f := newFakeTagger(map[string]string{schema.TagNIHDUAIDs: "phs000178"})
+	set, err := Grant(context.Background(), f, "researcher", "phs000178", expiry)
+	if err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if !reflect.DeepEqual(set, []string{"phs000178"}) {
+		t.Errorf("set = %v, want [phs000178] (no duplicate)", set)
+	}
+}
+
+func TestGrant_Validation(t *testing.T) {
+	f := newFakeTagger(nil)
+	if _, err := Grant(context.Background(), f, "", "phs000178", expiry); err == nil {
+		t.Error("empty role: want error")
+	}
+	if _, err := Grant(context.Background(), f, "researcher", "", expiry); err == nil {
+		t.Error("empty DUA: want error")
+	}
+	if _, err := Grant(context.Background(), f, "researcher", "phs+bad", expiry); err == nil {
+		t.Error("DUA containing delimiter: want error")
+	}
+	if _, err := Grant(context.Background(), f, "researcher", "phs000178", time.Time{}); err == nil {
+		t.Error("zero expiry: want error")
+	}
+}
+
+func TestGrant_ListError(t *testing.T) {
+	f := newFakeTagger(nil)
+	f.listErr = errors.New("AccessDenied")
+	if _, err := Grant(context.Background(), f, "researcher", "phs000178", expiry); err == nil {
+		t.Error("list error: want propagated error")
+	}
+}
+
+func TestRevoke_RemovesOneOfMany(t *testing.T) {
+	f := newFakeTagger(map[string]string{
+		schema.TagNIHApproval: "true",
+		schema.TagNIHDUAIDs:   "phs000178+phs000200",
+	})
+	set, err := Revoke(context.Background(), f, "researcher", "phs000178")
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if !reflect.DeepEqual(set, []string{"phs000200"}) {
+		t.Errorf("set = %v, want [phs000200]", set)
+	}
+	got := f.tags["researcher"]
+	if got[schema.TagNIHApproval] != "true" {
+		t.Error("approval should remain true while a DUA is left")
+	}
+	if got[schema.TagNIHDUAIDs] != "phs000200" {
+		t.Errorf("tag value = %q, want phs000200", got[schema.TagNIHDUAIDs])
+	}
+}
+
+func TestRevoke_LastDUAClearsApproval(t *testing.T) {
+	f := newFakeTagger(map[string]string{
+		schema.TagNIHApproval:       "true",
+		schema.TagNIHApprovalExpiry: "2027-05-01T00:00:00Z",
+		schema.TagNIHDUAIDs:         "phs000178",
+	})
+	set, err := Revoke(context.Background(), f, "researcher", "phs000178")
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if set != nil {
+		t.Errorf("set = %v, want nil (no DUAs left)", set)
+	}
+	got := f.tags["researcher"]
+	for _, k := range []string{schema.TagNIHApproval, schema.TagNIHApprovalExpiry, schema.TagNIHDUAIDs} {
+		if _, present := got[k]; present {
+			t.Errorf("tag %q should have been removed, got %q", k, got[k])
+		}
+	}
+}
+
+func TestRevoke_NotPresentIsNoError(t *testing.T) {
+	f := newFakeTagger(map[string]string{
+		schema.TagNIHApproval: "true",
+		schema.TagNIHDUAIDs:   "phs000178",
+	})
+	// Revoking a DUA the role doesn't hold leaves the existing set intact.
+	set, err := Revoke(context.Background(), f, "researcher", "phs999999")
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if !reflect.DeepEqual(set, []string{"phs000178"}) {
+		t.Errorf("set = %v, want [phs000178] unchanged", set)
+	}
+}


### PR DESCRIPTION
Build step 2 of the compute-to-data chain (provabl#11 Tier 2; ADR 0002 **Decision 2**). Closes the "compliance event → technical control" gap attest#99 names.

## What
`attest approval grant` **records** a signed DUA as a human-affirmed `schema.Attestation`, then **activates** it by writing the `attest:nih-approval`, `attest:nih-approval-expiry`, and `attest:nih-dua-ids` IAM role tags — the ones the principal resolver reads and `cedar-nih-approved-user` gates on. **No new evaluation path**: activation is the record + the tag write.

`attest approval revoke` removes one DUA.

## The load-bearing detail — the DUA set
A researcher accrues DUAs across studies, and compute-to-data (attest#100) binds each dataset to a *specific* DUA. So:
- **grant MERGES** the DUA into the `attest:nih-dua-ids` set (idempotent; sorted, `+`-joined via `schema.SetDelim`).
- **revoke removes one**, and **clears all approval tags** when the last DUA is gone — never leaving `attest:nih-approval=true` with an empty set (which would pass the blanket gate but fail every dataset-scoped check; we refuse that inconsistent state).

## Structure
- **`internal/approval`** — `Grant`/`Revoke` behind an injectable `RoleTagger` (3 methods → `iam:ListRoleTags`/`TagRole`/`UntagRole`). Fully unit-tested with a fake: first-grant, merge, idempotent, revoke-one-of-many, last-DUA-clears, revoke-absent, validation (empty role/DUA, delimiter in id, zero expiry), list-error propagation.
- **`cmd/attest approval`** — records the `Attestation` **first** (no IAM touch if it can't be written — no activation without a recorded basis), then activates via the AWS IAM client adapter.

## Honesty
- This is attest's **first IAM-role-write path** (it previously only *read* role tags and tagged Org accounts). Adds `iam:TagRole`/`iam:UntagRole`, documented **approval-only** in the suite `docs/required-permissions.md` (separate umbrella PR). Left out of the static `preflight` list, consistent with how the optional write paths (eventbridge/sqs) and nitro/tpm's conditional `ec2:DescribeImages` are handled.
- The dataset-scoped Cedar policy that **consumes** the set is **attest#100**, the next step — this PR is the producer.

Full attest suite passes (0 failures). Refs: provabl#11, attest#99.