### PR TITLE
feat(cedar): dataset-scoped NIH Approved-User gate (attest#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not a valid IAM tag-value character; `+` is, and DUA/phs ids never contain it — `schema.SetDelim`).
   The schema JSON (byte-identical in both repos), `SchemaVersion` (1→2), the conformance test's
   allowed types (adds `set`), the nih-gds framework's principal attributes, and the resolver all
-  move together. This is the first key change to exercise the qualify#32 versioned-schema guard. No
-  producer yet writes the singular key (attest#99's `attest approval` command is unbuilt), so this is
-  a clean rename with nothing deployed to be compatible with.
+  move together. This is the first key change to exercise the qualify#32 versioned-schema guard.
+  Producer: `attest approval` (above). Consumer: the dataset-scoped policy (below).
+- **NIH Approved-User gate is now dataset-scoped** (attest#100; provabl#11, ADR 0002 Decision 3). The
+  `cedar-nih-approved-user` policy (nih-gds 1.1) was **blanket** — `principal.nih_approval_current ==
+  true` against any `nih_controlled_access` resource — so approval for one study granted access to
+  every controlled dataset. It now also requires
+  `principal.nih_approval_dua_ids.contains(resource.dua_id)`: a researcher reaches a dataset only with
+  the DUA *that* dataset requires. Three coupled changes make the set usable end to end: the evaluator
+  lowers a `[]string` attribute to a real Cedar `Set` (`toValue`, previously stringified); the
+  compiler types plural-`ids` attributes as `Set<String>` (`inferCedarType` — singular `dua_id`/
+  `repository_id` stay `String`); and the nih-gds inline `cedar_policy` carries the membership clause.
+  Proven by a real cedar-go evaluation test (holds-required-DUA → ALLOW; wrong-DUA, empty-set,
+  unapproved → DENY; non-controlled resource → ALLOW) and a compile+parse test on the framework. This
+  is a **tightening**: no principal gains access they lacked. Consumes the `attest:nih-dua-ids` set
+  the new `attest approval` command writes.
 - **Go 1.26.4**: bumped the `go` directive to clear the GO-2026-* standard-library advisories the
   weekly Security Scan flagged. (#101)
 - Copyright holder normalized to Playground Logic LLC.

--- a/frameworks/nih-gds/framework.yaml
+++ b/frameworks/nih-gds/framework.yaml
@@ -70,8 +70,11 @@ controls:
       - id: cedar-nih-approved-user
         description: >
           Principal must have active NIH Approved User status (attest:nih-approval=true
-          with non-expired attest:nih-approval-expiry) to access NIH controlled-access
-          resources. Covers all actions on resources tagged nih_controlled_access=true.
+          with non-expired attest:nih-approval-expiry) AND hold the specific DUA the
+          dataset requires (resource.dua_id must be a member of the principal's
+          attest:nih-dua-ids set) to access an NIH controlled-access resource. Being
+          approved for one study no longer grants access to another. Covers all actions
+          on resources tagged nih_controlled_access=true.
         entities:
           - principal
           - nih_resource
@@ -92,7 +95,7 @@ controls:
               Without current NIH approval records in the principal resolver,
               Cedar evaluates nih_approval_current=false and denies all access
               to NIH controlled-access resources.
-        cedar_policy: "// NIH GDS 1.1 — Approved User gate\nforbid (\n  principal,\n  action,\n  resource\n)\nwhen {\n  resource has nih_controlled_access &&\n  resource.nih_controlled_access == true &&\n  !(principal has nih_approval_current &&\n    principal.nih_approval_current == true)\n};\n"
+        cedar_policy: "// NIH GDS 1.1 — Approved User gate (dataset-scoped)\nforbid (\n  principal,\n  action,\n  resource\n)\nwhen {\n  resource has nih_controlled_access &&\n  resource.nih_controlled_access == true &&\n  !(principal has nih_approval_current &&\n    principal.nih_approval_current == true &&\n    principal has nih_approval_dua_ids &&\n    resource has dua_id &&\n    principal.nih_approval_dua_ids.contains(resource.dua_id))\n};\n"
         temporal:
           condition_type: expiry
           description: >

--- a/internal/compiler/cedar/compiler.go
+++ b/internal/compiler/cedar/compiler.go
@@ -95,7 +95,7 @@ func (c *Compiler) Compile(rcs *framework.ResolvedControlSet) ([]CompiledCedarPo
 func (c *Compiler) BuildSchema(rcs *framework.ResolvedControlSet) string {
 	// Collect all entity types and actions across all controls.
 	entityDefs := make(map[string]map[string]string) // entity name → attr → Cedar type
-	actionDefs := make(map[string][]string)           // action name → principal+resource types
+	actionDefs := make(map[string][]string)          // action name → principal+resource types
 
 	for _, controls := range rcs.Operational {
 		for _, rc := range controls {
@@ -294,8 +294,10 @@ func inferCedarType(attr string) string {
 		}
 	}
 
-	// Set indicators.
-	for _, keyword := range []string{"protocols", "membership", "classes", "groups", "tags"} {
+	// Set indicators. "ids" (plural) catches set-valued id attributes like
+	// nih_approval_dua_ids while leaving singular ids (dua_id, repository_id) as
+	// String below — the plural check runs first, so it wins.
+	for _, keyword := range []string{"protocols", "membership", "classes", "groups", "tags", "ids"} {
 		if strings.Contains(lower, keyword) {
 			return "Set<String>"
 		}

--- a/internal/compiler/cedar/compiler_test.go
+++ b/internal/compiler/cedar/compiler_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	cedar "github.com/cedar-policy/cedar-go"
+
 	"github.com/provabl/attest/internal/framework"
 	"github.com/provabl/attest/pkg/schema"
 )
@@ -95,9 +97,9 @@ unless { resource.encrypted == true };`
 
 func TestTemporalConstraints(t *testing.T) {
 	tests := []struct {
-		name           string
-		conditionType  string
-		wantContains   string
+		name          string
+		conditionType string
+		wantContains  string
 	}{
 		{"expiry", "expiry", "principal.training_expiry"},
 		{"event", "event", "principal.irb_active"},
@@ -210,6 +212,11 @@ func TestInferCedarType(t *testing.T) {
 		{"cui_training_expiry", "Long"},
 		{"irb_protocols", "Set<String>"},
 		{"lab_membership", "Set<String>"},
+		// Plural id → Set; singular ids stay String (the dataset-scoped DUA model).
+		{"nih_approval_dua_ids", "Set<String>"},
+		{"dua_id", "String"},
+		{"repository_id", "String"},
+		{"source_dua_id", "String"},
 	}
 
 	for _, tt := range tests {
@@ -293,5 +300,55 @@ func TestCompileFullFramework(t *testing.T) {
 		if p.PolicyText == "" {
 			t.Errorf("policy %s has empty text", p.ID)
 		}
+	}
+}
+
+// TestCompileNIHGDSDatasetScoped verifies the dataset-scoped Approved-User gate
+// (attest#100): the nih-gds 1.1 inline cedar_policy compiles, carries the
+// .contains(resource.dua_id) membership clause, parses cleanly through cedar-go,
+// and that nih_approval_dua_ids is typed Set<String> (not String) in the schema.
+func TestCompileNIHGDSDatasetScoped(t *testing.T) {
+	loader := framework.NewLoader("../../../frameworks")
+	fw, err := loader.Load("nih-gds")
+	if err != nil {
+		t.Fatalf("Load(nih-gds) error = %v", err)
+	}
+	rcs, err := framework.Resolve([]*schema.Framework{fw})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	c := NewCompiler()
+	policies, err := c.Compile(rcs)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	var found bool
+	for _, p := range policies {
+		if !strings.Contains(p.PolicyText, "nih_approval_dua_ids") {
+			continue
+		}
+		found = true
+		if !strings.Contains(p.PolicyText, "nih_approval_dua_ids.contains(resource.dua_id)") {
+			t.Errorf("policy %s lacks the dataset-scoped .contains(resource.dua_id) clause:\n%s", p.ID, p.PolicyText)
+		}
+		// The inline policy must parse through the real Cedar engine.
+		if _, err := cedar.NewPolicySetFromBytes(p.ID+".cedar", []byte(p.PolicyText)); err != nil {
+			t.Errorf("policy %s does not parse through cedar-go: %v\n%s", p.ID, err, p.PolicyText)
+		}
+		// nih_approval_dua_ids must be a Set, not a String, in the entity schema.
+		for _, et := range p.Entities.Types {
+			if ct, ok := et.Attributes["nih_approval_dua_ids"]; ok && ct != "Set<String>" {
+				t.Errorf("nih_approval_dua_ids typed %q, want Set<String>", ct)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no compiled nih-gds policy referenced nih_approval_dua_ids")
+	}
+
+	// The full nih-gds schema must also parse as a Cedar schema.
+	if schemaText := c.BuildSchema(rcs); schemaText == "" {
+		t.Fatal("BuildSchema() returned empty string")
 	}
 }

--- a/internal/evaluator/dataset_scope_test.go
+++ b/internal/evaluator/dataset_scope_test.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+	"testing"
+
+	cedar "github.com/cedar-policy/cedar-go"
+)
+
+// The dataset-scoped NIH Approved-User gate (nih-gds 1.1; provabl ADR 0002,
+// attest#100). A base permit plus the forbid-unless that binds the dataset's
+// required DUA to the principal's approved-DUA set — being approved for one study
+// must NOT grant access to another. This exercises the real cedar-go engine end to
+// end, including the []string → Cedar Set lowering in toValue and the
+// .contains(resource.dua_id) membership test.
+const datasetScopedNIHPolicy = `permit(principal, action, resource);
+forbid (principal, action, resource)
+when {
+  resource has nih_controlled_access &&
+  resource.nih_controlled_access == true &&
+  !(principal has nih_approval_current &&
+    principal.nih_approval_current == true &&
+    principal has nih_approval_dua_ids &&
+    resource has dua_id &&
+    principal.nih_approval_dua_ids.contains(resource.dua_id))
+};`
+
+func nihPolicySet(t *testing.T) *cedar.PolicySet {
+	t.Helper()
+	ps, err := cedar.NewPolicySetFromBytes("nih.cedar", []byte(datasetScopedNIHPolicy))
+	if err != nil {
+		t.Fatalf("parse dataset-scoped NIH policy: %v", err)
+	}
+	return ps
+}
+
+func evalDataset(t *testing.T, attrs map[string]any) string {
+	t.Helper()
+	ev := NewEvaluator(nil)
+	req := &AuthzRequest{
+		PrincipalARN: "arn:aws:iam::123456789012:role/researcher",
+		Action:       "s3:GetObject",
+		ResourceARN:  "arn:aws:s3:::dbgap-dataset",
+		Attributes:   attrs,
+	}
+	d, err := ev.EvaluateWithPolicies(context.Background(), nihPolicySet(t), req)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	return d.Effect
+}
+
+// Approved for the dataset's required DUA → permitted.
+func TestDatasetScope_HoldsRequiredDUA(t *testing.T) {
+	got := evalDataset(t, map[string]any{
+		"principal.nih_approval_current": true,
+		"principal.nih_approval_dua_ids": []string{"phs000178", "phs000200"},
+		"resource.nih_controlled_access": true,
+		"resource.dua_id":                "phs000178",
+	})
+	if got != "ALLOW" {
+		t.Errorf("holder of phs000178 accessing phs000178 dataset: got %s, want ALLOW", got)
+	}
+}
+
+// Approved for a DIFFERENT study than the dataset requires → denied. This is the
+// whole point of the change: blanket NIH approval no longer crosses datasets.
+func TestDatasetScope_WrongDUA(t *testing.T) {
+	got := evalDataset(t, map[string]any{
+		"principal.nih_approval_current": true,
+		"principal.nih_approval_dua_ids": []string{"phs000178"},
+		"resource.nih_controlled_access": true,
+		"resource.dua_id":                "phs000200",
+	})
+	if got != "DENY" {
+		t.Errorf("holder of only phs000178 accessing phs000200 dataset: got %s, want DENY", got)
+	}
+}
+
+// Not an approved user at all → denied.
+func TestDatasetScope_NotApproved(t *testing.T) {
+	got := evalDataset(t, map[string]any{
+		"principal.nih_approval_current": false,
+		"resource.nih_controlled_access": true,
+		"resource.dua_id":                "phs000178",
+	})
+	if got != "DENY" {
+		t.Errorf("unapproved principal: got %s, want DENY", got)
+	}
+}
+
+// An approved user with an empty DUA set → denied (no dataset matches an empty
+// set). Guards the inconsistent state approval.Revoke refuses to write.
+func TestDatasetScope_EmptyDUASet(t *testing.T) {
+	got := evalDataset(t, map[string]any{
+		"principal.nih_approval_current": true,
+		"principal.nih_approval_dua_ids": []string{},
+		"resource.nih_controlled_access": true,
+		"resource.dua_id":                "phs000178",
+	})
+	if got != "DENY" {
+		t.Errorf("approved user with empty DUA set: got %s, want DENY", got)
+	}
+}
+
+// A resource that is not NIH controlled-access is unaffected by the gate.
+func TestDatasetScope_NonControlledResource(t *testing.T) {
+	got := evalDataset(t, map[string]any{
+		"principal.nih_approval_current": false,
+		"resource.nih_controlled_access": false,
+	})
+	if got != "ALLOW" {
+		t.Errorf("non-controlled resource: got %s, want ALLOW", got)
+	}
+}

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -113,12 +113,12 @@ func (e *Evaluator) EvaluateWithPolicies(ctx context.Context, ps *cedar.PolicySe
 	}
 
 	d := &schema.CedarDecision{
-		Timestamp:   now,
-		Action:      req.Action,
-		Principal:   req.PrincipalARN,
-		Resource:    req.ResourceARN,
-		Effect:      effect,
-		AccountID:   req.AccountID,
+		Timestamp: now,
+		Action:    req.Action,
+		Principal: req.PrincipalARN,
+		Resource:  req.ResourceARN,
+		Effect:    effect,
+		AccountID: req.AccountID,
 	}
 
 	// Extract policy ID from diagnostics.
@@ -347,6 +347,14 @@ func toValue(v any) types.Value {
 		return types.Long(val)
 	case float64:
 		return types.Long(int64(val))
+	case []string:
+		// Set-typed attribute (e.g. principal.nih_approval_dua_ids) — needed for
+		// Cedar membership tests like principal.nih_approval_dua_ids.contains(...).
+		elems := make([]types.Value, 0, len(val))
+		for _, s := range val {
+			elems = append(elems, types.String(s))
+		}
+		return types.NewSet(elems...)
 	default:
 		return types.String(fmt.Sprintf("%v", v))
 	}


### PR DESCRIPTION
Build step 3 of the compute-to-data chain (provabl#11 Tier 2; ADR 0002 **Decision 3**). The consumer of the DUA set that `attest approval` (attest#99, just merged) produces.

## The problem
`cedar-nih-approved-user` (nih-gds 1.1) was **blanket**: `principal.nih_approval_current == true` against any `nih_controlled_access` resource. A researcher approved for **one** study could reach **every** controlled dataset — the TOCTOU-equivalent for data access.

## The fix
Bind per-dataset: the gate now also requires
```
principal.nih_approval_dua_ids.contains(resource.dua_id)
```
A researcher reaches a dataset only with the DUA *that dataset* requires.

## Three coupled changes make the set usable end to end
1. **evaluator `toValue`** — lower a `[]string` attribute to a real Cedar `types.Set`. Previously it hit the `default` branch and **stringified**, so `.contains()` could never have worked.
2. **compiler `inferCedarType`** — plural `ids` → `Set<String>`, checked *before* the `id` string-indicator, so `nih_approval_dua_ids` types correctly while singular `dua_id`/`repository_id`/`source_dua_id` stay `String`.
3. **nih-gds `framework.yaml`** — the inline `cedar_policy` gains the `.contains(resource.dua_id)` clause (with `has` guards) + a dataset-scoped description.

## Tests (real cedar-go engine, not string matching)
- `dataset_scope_test.go`: holds-required-DUA → **ALLOW**; wrong-DUA / empty-set / unapproved → **DENY**; non-controlled resource → **ALLOW**.
- `compiler_test.go`: `inferCedarType` plural-vs-singular; nih-gds compiles, carries the `.contains` clause, **parses through cedar-go**, and types the set as `Set<String>`.

## Honesty
- A **tightening**: no principal gains access they previously lacked (a holder of the old blanket approval may now be denied a dataset they hold no DUA for — the point).
- The `empty DUA set → DENY` case guards the inconsistent state `approval.Revoke` already refuses to write.
- Full attest suite passes (0 failures).

With this, the **attest side of compute-to-data is complete** (produce the DUA set → bind it per-dataset). The remaining chain item is ground#10 (network egress). Refs: provabl#11, attest#100.